### PR TITLE
skip if python not available

### DIFF
--- a/R/spacy_initialize.R
+++ b/R/spacy_initialize.R
@@ -42,7 +42,7 @@ spacy_initialize <- function(model = "en",
     }
     # once python is initialized, you cannot change the python executables
     if(!is.null(options("python_initialized")$python_initialized)) {
-        message("Python space is already attached.  If you want to swtich to a different Python, please restart R.")
+        message("Python space is already attached.  If you want to switch to a different Python, please restart R.")
     } 
     else {
         set_spacy_python_option(python_executable, 

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ This is an example of parsing German texts.
 ## first finalize the spacy if it's loaded
 spacy_finalize()
 spacy_initialize(model = "de")
-## Python space is already attached.  If you want to swtich to a different Python, please restart R.
+## Python space is already attached.  If you want to switch to a different Python, please restart R.
 ## successfully initialized (spaCy Version: 2.0.2, language model: de)
 
 txt_german <- c(R = "R ist eine freie Programmiersprache für statistische Berechnungen und Grafiken. Sie wurde von Statistikern für Anwender mit statistischen Aufgaben entwickelt.",

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,5 +1,8 @@
 ## Submission notes
 
+### Resubmission
+
+We submitted a version that failed on Solaris (the only environment for which we ahd no testing platform) because Python was unavailable on that system.  We wish to retain the 1.0 version if possible.
 
 ### Purpose
 

--- a/tests/testthat/test-1-spacy_initialize.R
+++ b/tests/testthat/test-1-spacy_initialize.R
@@ -1,6 +1,8 @@
 context("test spacy_initialize")
 
 test_that("spacy_initialize() with non-existent python (#49)", {
+    if (!reticulate::py_available(initialize = TRUE))
+        skip("Python bindings not available for testing")
     expect_error(
         spacy_initialize(python_executable = "/usr/local/bin/notpython"),
         "notpython is not a python executable"

--- a/tests/testthat/test-1-spacy_initialize.R
+++ b/tests/testthat/test-1-spacy_initialize.R
@@ -1,7 +1,7 @@
 context("test spacy_initialize")
 
 test_that("spacy_initialize() with non-existent python (#49)", {
-    if (!reticulate::py_available(initialize = TRUE))
+    if (!reticulate::py_available(initialize = FALSE))
         skip("Python bindings not available for testing")
     expect_error(
         spacy_initialize(python_executable = "/usr/local/bin/notpython"),

--- a/tests/testthat/test-2-spacy_parse.R
+++ b/tests/testthat/test-2-spacy_parse.R
@@ -3,6 +3,7 @@ context("test spacy_parse")
 test_that("spacy_parse handles newlines and tabs ok", {
     skip_on_cran()
     skip_on_appveyor()
+    skip_on_os("solaris")
     expect_message(spacy_initialize(), "successfully")
     
     txt1 <- c(doc1 = "Sentence one.\nSentence two.", 
@@ -35,6 +36,7 @@ test_that("spacy_parse handles newlines and tabs ok", {
 test_that("spacy_parse handles quotes ok", {
     skip_on_cran()
     skip_on_appveyor()
+    skip_on_os("solaris")
     expect_message(spacy_initialize(), "successfully")
 
     txt1 <- c(doc1 = "Sentence \"quoted\" one.", 

--- a/tests/testthat/test-3-entity-functions.R
+++ b/tests/testthat/test-3-entity-functions.R
@@ -3,6 +3,8 @@ context("testing entity functions")
 test_that("getting named entities works", {
     skip_on_cran()
     skip_on_appveyor()
+    skip_on_os("solaris")
+    
     expect_message(spacy_initialize(), "successfully")
     
     txt1 <- c(doc1 = "The United States elected President Donald Trump, from New York.", 
@@ -45,6 +47,7 @@ test_that("getting named entities works", {
 test_that("entity consolidation works", {
     skip_on_cran()
     skip_on_appveyor()
+    skip_on_os("solaris")
     expect_message(spacy_initialize(), "successfully")
     
     txt1 <- c(doc1 = "The United States elected President Donald Trump, from New York.", 

--- a/tests/testthat/test-4-quanteda-methods.R
+++ b/tests/testthat/test-4-quanteda-methods.R
@@ -3,6 +3,7 @@ context("test quanteda functions")
 test_that("quanteda functions work", {
     skip_on_cran()
     skip_on_appveyor()
+    skip_on_os("solaris")
     skip_if_not_installed("quanteda")
     
     spacy_initialize()


### PR DESCRIPTION
Dealing with the Solaris build failure. Skipping the test for `spacy_initialize` if python does not exist in the system.