### PR TITLE
Improve tests

### DIFF
--- a/R/spacy_initialize.R
+++ b/R/spacy_initialize.R
@@ -179,7 +179,11 @@ find_spacy <- function(model = "en", ask, source_bash_profile){
 check_spacy_model <- function(py_exec, model) {
     options(warn = -1)
     py_exist <- if(Sys.info()['sysname'] == "Windows") {
-        system2("where", py_exec, stdout = TRUE)
+        if(py_exec %in% system2("where", "python", stdout = TRUE)) {
+            py_exec
+        } else {
+            NULL
+        }
     } else {
         system2('which', py_exec, stdout = TRUE)
     }

--- a/R/spacy_initialize.R
+++ b/R/spacy_initialize.R
@@ -137,7 +137,7 @@ find_spacy <- function(model = "en", ask, source_bash_profile){
     options(warn = 0)
     
     if (length(py_execs) == 0 | grepl("not find", py_execs[1])[1]){
-        stop("No python was found on system PATH")
+        return(NA)
     }
     df_python_check <- data.table::data.table(py_execs, spacy_found = 0)
     for (i in 1:nrow(df_python_check)) {
@@ -234,12 +234,15 @@ set_spacy_python_option <- function(python_executable = NULL,
     }
     else {
         message("Finding a python executable with spacy installed...")
-        spacy_python <- find_spacy(model, ask = ask, source_bash_profile = source_bash_profile)
-        if(!is.null(spacy_python)){
+        spacy_python <- find_spacy(model, ask = ask, 
+                                   source_bash_profile = source_bash_profile)
+        if (is.null(spacy_python)) {
+            stop("spaCy or language model ", model, " is not installed in any of python executables.")
+        } else if(is.na(spacy_python)) {
+            stop("No python was found on system PATH")
+        } else {
             options(spacy_python_setting = list(type = "python_executable",
                                                 py_path = spacy_python))
-        } else {
-            stop("spaCy or language model ", model, " is not installed in any of python executables.")
         }
     }
     return(NULL)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,18 @@
 # DO NOT CHANGE the "init" and "install" sections below
 
+image: Visual Studio 2015
+
+environment:
+  NOT_CRAN: true
+  USE_RTOOLS: true
+  PATH: "%PATH%;C:\\MinGW\\bin;C:\\MinGW\\msys\\1.0;C:\\MinGW\\msys\\1.0\\bin"
+  matrix:
+    - PYTHON: "C:\\Python36"
+      RETICULATE_PYTHON: "C:\\Python36"
+
+matrix:
+  fast_finish: true
+
 # Download script file from GitHub
 init:
   ps: |
@@ -12,6 +25,8 @@ install:
   ps: Bootstrap
 
 build_script:
+  - "%PYTHON%\\python.exe -m pip install setuptools spacy"
+  - "%PYTHON%\\python.exe -m spacy download en"
   - travis-tool.sh install_deps
 
 test_script:

--- a/tests/testthat/test-1-spacy_initialize.R
+++ b/tests/testthat/test-1-spacy_initialize.R
@@ -1,8 +1,7 @@
 context("test spacy_initialize")
 
 test_that("spacy_initialize() with non-existent python (#49)", {
-    if (!reticulate::py_available(initialize = FALSE))
-        skip("Python bindings not available for testing")
+    skip_on_os("solaris")
     expect_error(
         spacy_initialize(python_executable = "/usr/local/bin/notpython"),
         "notpython is not a python executable"

--- a/tests/testthat/test-2-spacy_parse.R
+++ b/tests/testthat/test-2-spacy_parse.R
@@ -3,7 +3,7 @@ source("utils.R")
 
 test_that("spacy_parse handles newlines and tabs ok", {
     skip_on_cran()
-    skip_on_appveyor()
+    # skip_on_appveyor()
     skip_on_os("solaris")
     skip_if_no_python_or_no_spacy()
     expect_message(spacy_initialize(), "successfully")
@@ -37,7 +37,7 @@ test_that("spacy_parse handles newlines and tabs ok", {
 
 test_that("spacy_parse handles quotes ok", {
     skip_on_cran()
-    skip_on_appveyor()
+    # skip_on_appveyor()
     skip_on_os("solaris")
     skip_if_no_python_or_no_spacy()
     expect_message(spacy_initialize(), "successfully")

--- a/tests/testthat/test-2-spacy_parse.R
+++ b/tests/testthat/test-2-spacy_parse.R
@@ -1,9 +1,11 @@
 context("test spacy_parse")
+source("utils.R")
 
 test_that("spacy_parse handles newlines and tabs ok", {
     skip_on_cran()
     skip_on_appveyor()
     skip_on_os("solaris")
+    skip_if_no_python_or_no_spacy()
     expect_message(spacy_initialize(), "successfully")
     
     txt1 <- c(doc1 = "Sentence one.\nSentence two.", 

--- a/tests/testthat/test-2-spacy_parse.R
+++ b/tests/testthat/test-2-spacy_parse.R
@@ -39,6 +39,7 @@ test_that("spacy_parse handles quotes ok", {
     skip_on_cran()
     skip_on_appveyor()
     skip_on_os("solaris")
+    skip_if_no_python_or_no_spacy()
     expect_message(spacy_initialize(), "successfully")
 
     txt1 <- c(doc1 = "Sentence \"quoted\" one.", 

--- a/tests/testthat/test-3-entity-functions.R
+++ b/tests/testthat/test-3-entity-functions.R
@@ -50,6 +50,7 @@ test_that("entity consolidation works", {
     skip_on_cran()
     skip_on_appveyor()
     skip_on_os("solaris")
+    skip_if_no_python_or_no_spacy()
     expect_message(spacy_initialize(), "successfully")
     
     txt1 <- c(doc1 = "The United States elected President Donald Trump, from New York.", 

--- a/tests/testthat/test-3-entity-functions.R
+++ b/tests/testthat/test-3-entity-functions.R
@@ -1,9 +1,11 @@
 context("testing entity functions")
+source("utils.R")
 
 test_that("getting named entities works", {
     skip_on_cran()
     skip_on_appveyor()
     skip_on_os("solaris")
+    skip_if_no_python_or_no_spacy()
     
     expect_message(spacy_initialize(), "successfully")
     

--- a/tests/testthat/test-3-entity-functions.R
+++ b/tests/testthat/test-3-entity-functions.R
@@ -3,7 +3,7 @@ source("utils.R")
 
 test_that("getting named entities works", {
     skip_on_cran()
-    skip_on_appveyor()
+    # skip_on_appveyor()
     skip_on_os("solaris")
     skip_if_no_python_or_no_spacy()
     
@@ -48,7 +48,7 @@ test_that("getting named entities works", {
 
 test_that("entity consolidation works", {
     skip_on_cran()
-    skip_on_appveyor()
+    # skip_on_appveyor()
     skip_on_os("solaris")
     skip_if_no_python_or_no_spacy()
     expect_message(spacy_initialize(), "successfully")

--- a/tests/testthat/test-4-quanteda-methods.R
+++ b/tests/testthat/test-4-quanteda-methods.R
@@ -1,10 +1,12 @@
 context("test quanteda functions")
+source("utils.R")
 
 test_that("quanteda functions work", {
     skip_on_cran()
     skip_on_appveyor()
     skip_on_os("solaris")
     skip_if_not_installed("quanteda")
+    skip_if_no_python_or_no_spacy()
     
     spacy_initialize()
     

--- a/tests/testthat/test-4-quanteda-methods.R
+++ b/tests/testthat/test-4-quanteda-methods.R
@@ -3,7 +3,7 @@ source("utils.R")
 
 test_that("quanteda functions work", {
     skip_on_cran()
-    skip_on_appveyor()
+    # skip_on_appveyor()
     skip_on_os("solaris")
     skip_if_not_installed("quanteda")
     skip_if_no_python_or_no_spacy()

--- a/tests/testthat/utils.R
+++ b/tests/testthat/utils.R
@@ -1,0 +1,13 @@
+skip_if_no_python_or_no_spacy <- function() {
+    if(Sys.info()['sysname'] == "Windows"){
+        source_bash_profile <- FALSE
+    } else {
+        source_bash_profile <- TRUE
+    }
+    spacy_path <- find_spacy(ask = FALSE, source_bash_profile = source_bash_profile)
+    if(is.null(spacy_path)) {
+        skip("Skip the test as spaCy is not found")
+    } else if (is.na(spacy_path)) {
+        skip("Skip the test as python is not found")
+    }
+}


### PR DESCRIPTION
This is the enhancement of tests for the package.

1.  The biggest change is the appveyor build. This branch has the proper tests for windows (installation of spacyr and actual tests).
2. Implementation of `skip_if_no_python_or_no_spacy()`.  Because of this, I believe that `skip_on_cran()` is not necessary anymore to pass the cran check but I didn't remove them (just in case...). This also supposedly resolve #88 
3. Tests for `solaris` on cran are skipped entirely (this should not be an issue as no one install python on solaris for using spaCy...)

