### PR TITLE
Improvement on spacy_install()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ before_script:
   - sudo apt-get update
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda
+  - rm miniconda.sh
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no

--- a/R/spacy_initialize.R
+++ b/R/spacy_initialize.R
@@ -121,7 +121,7 @@ spacy_initialize <- function(model = "en",
 #' @author Akitaka Matsuo
 spacy_finalize <- function() {
     if (is.null(getOption("spacy_initialized"))) {
-        stop("Nothing to finalize. Spacy is not initialized")
+        stop("Nothing to finalize. spaCy is not initialized")
     }
     spacyr_pyexec(pyfile = system.file("python", "finalize_spacyPython.py",
                                        package = "spacyr"))
@@ -298,7 +298,7 @@ set_spacy_python_option <- function(python_executable = NULL,
             options(spacy_condaenv = condaenv)
         }
     } else {
-        message("Finding a python executable with spacy installed...")
+        message("Finding a python executable with spaCy installed...")
         spacy_python <- find_spacy(model, ask = ask)
         if (is.null(spacy_python)) {
             stop("spaCy or language model ", model, " is not installed in any of python executables.")

--- a/R/spacy_initialize.R
+++ b/R/spacy_initialize.R
@@ -96,7 +96,7 @@ spacy_initialize <- function(model = "en",
                                        package = "spacyr"))
 
     spacy_version <- spacyr_pyget("versions")$spacy
-    if(entity == FALSE & as.integer(substr(spacy_version, 1, 1)) < 2){
+    if(entity == FALSE && as.integer(substr(spacy_version, 1, 1)) < 2){
         message("entity == FALSE is only available for spaCy version 2.0.0 or higher")
         options("spacy_entity" = TRUE)
     }
@@ -150,7 +150,7 @@ find_spacy <- function(model = "en", ask){
     # }
     py_execs <- if(is_windows()) {
         system2("where", "python", stdout = TRUE)
-    } else if(is_osx() & file.exists("~/.bash_profile")) {
+    } else if(is_osx() && file.exists("~/.bash_profile")) {
         c(system2("source", "~/.bash_profile; which -a python", stdout = TRUE),
           system2("source", "~/.bash_profile; which -a python3", stdout = TRUE))
     } else {
@@ -211,6 +211,9 @@ find_spacy <- function(model = "en", ask){
 #'  
 #' @keywords internal
 find_spacy_env <- function(){
+    if(is.null(tryCatch(reticulate::conda_binary("auto"), error = function(e) NULL))){
+        return(FALSE)        
+    }
     found <- if("spacy_condaenv" %in% reticulate::conda_list(conda = "auto")$name) {
         TRUE
     } else if(file.exists(file.path( "~/.virtualenvs", "spacy_virtualenv", "bin", "activate"))) {
@@ -260,12 +263,14 @@ set_spacy_python_option <- function(python_executable = NULL,
         settings <- check_spacy_python_options()
         message("spacy python option is already set, spacyr will use:\n\t",
                 sub("spacy_", "", settings$key), ' = "', settings$val, '"')
-    } else if(check_env & "spacy_condaenv" %in% reticulate::conda_list(conda = "auto")$name) {
+    } else if(check_env && 
+              !(is.null(tryCatch(reticulate::conda_binary("auto"), error = function(e) NULL))) && 
+              "spacy_condaenv" %in% reticulate::conda_list(conda = "auto")$name) {
         message("Found 'spacy_condaenv'. spacyr will use this environment")
         clear_spacy_options()
         options(spacy_condaenv = "spacy_condaenv")
     }
-    else if(check_env & file.exists(file.path( "~/.virtualenvs", "spacy_virtualenv", "bin", "activate"))) {
+    else if(check_env && file.exists(file.path( "~/.virtualenvs", "spacy_virtualenv", "bin", "activate"))) {
         message("Found 'spacy_virtualenv'. spacyr will use this environment")
         clear_spacy_options()
         options(spacy_virtualenv = "~/.virtualenvs/spacy_virtualenv")

--- a/R/spacy_install.R
+++ b/R/spacy_install.R
@@ -12,6 +12,14 @@
 #'   locate and use an existing installation automatically, or download and
 #'   install one if none exists.  The miniconda installation is not currently
 #'   available on Windows.
+#'   
+#'   Regarding the installation option, \code{version="latest_v1"}. At the moment, 
+#'   there is a performance issue for spaCy pipeline for spacy v2.*. This can  enormously 
+#'   affect the performance of \code{spacy_parse()}, especially when a large number of 
+#'   small texts are parseed. For this reason, the package \code{spacyr}
+#'   provides an option to automatically install the latest version of spacy v1.*.
+#'   
+#'   The details of this performance issue are available at spaCy issue \href{https://github.com/explosion/spaCy/issues/1508}{#1508: v2 standard pipeline running 10x slower}
 #'
 #' @inheritParams reticulate::conda_list
 #' @param conda character; path to conda executable. Default "auto" which

--- a/R/spacy_install.R
+++ b/R/spacy_install.R
@@ -124,7 +124,8 @@ spacy_install <- function(conda = "auto",
                                          envname = envname)
              
     }
-    cat("\nInstallation complete.\n\n")
+    message("\nInstallation complete.\n",
+            sprintf("Condaenv: %s; Langage model(s):", envname), lang_models, "\n")
     
     invisible(NULL)
 }

--- a/R/spacy_install.R
+++ b/R/spacy_install.R
@@ -132,7 +132,7 @@ spacy_install <- function(conda = "auto",
  
     }
     message("\nInstallation complete.\n",
-            sprintf("Condaenv: %s; Langage model(s):", envname), lang_models, "\n")
+            sprintf("Condaenv: %s; Langage model(s): ", envname), lang_models, "\n")
 
     invisible(NULL)
 }

--- a/R/spacy_install.R
+++ b/R/spacy_install.R
@@ -10,17 +10,23 @@
 #'   \code{spacy_install}.  Alternatively, an existing conda installation may be
 #'   used, by specifying its path.  The default setting of \code{"auto"} will
 #'   locate and use an existing installation automatically, or download and
-#'   install one if none exists.  The miniconda installation is not currently
-#'   available on Windows.
+#'   install one if none exists.  
 #'   
-#'   Regarding the installation option, \code{version="latest_v1"}. At the moment, 
-#'   there is a performance issue for spaCy pipeline for spacy v2.*. This can  enormously 
-#'   affect the performance of \code{spacy_parse()}, especially when a large number of 
-#'   small texts are parseed. For this reason, the package \code{spacyr}
-#'   provides an option to automatically install the latest version of spacy v1.*.
-#'   
-#'   The details of this performance issue are available at spaCy issue \href{https://github.com/explosion/spaCy/issues/1508}{#1508: v2 standard pipeline running 10x slower}
+#'   For Windows, automatic installation of miniconda installation is not currently
+#'   available, so the user will need to \href{https://conda.io/docs/user-guide/install/windows.html}{miniconda (or Anaconda) manually}.
 #'
+#' @section spaCy Version Issues:
+#' 
+#'   The version options currently default to the latest spaCy v2 (\code{version
+#'   = "latest"}). As of 2018-04, however,
+#'   \href{https://github.com/explosion/spaCy/issues/1508}{some performance
+#'   issues} affect the speed of the spaCy pipeline for spacy v2.x relative to
+#'   v1.x.   This can  enormously affect the performance of
+#'   \code{spacy_parse()}, especially when a large number of small texts are
+#'   parseed. For this reason, the \pkg{spacyr} provides an option to
+#'   automatically install the latest version of spacy v1.*, using \code{version
+#'   = "latest_v1"}.
+#'   
 #' @inheritParams reticulate::conda_list
 #' @param conda character; path to conda executable. Default "auto" which
 #'   automatically find the path
@@ -29,7 +35,7 @@
 #'   (e.g. \code{c("en", "de")})
 #' @param version character; spaCy version to install. Specify \code{"latest"}
 #'   to install the latest release, or \code{"latest_v1"} to install the latest 
-#'   release of spacy v1.*
+#'   release of spacy v1.*.  See spaCy Version Issues.
 #'
 #'   You can also provide a full major.minor.patch specification (e.g. "1.1.0")
 #' @param python_version character; determine Python version for condaenv

--- a/R/spacy_install.R
+++ b/R/spacy_install.R
@@ -26,6 +26,8 @@
 #' @param python_version character; determine Python version for condaenv
 #'   installation. 3.5 and 3.6 are available.
 #' @param python_path character; path to Python in virtualenv installation
+#' @param envname character; name of the conda-environment to install spacy. 
+#'   Default is "spacy_condaenv".
 #' @param prompt logical; ask whether to proceed during the installation
 #' @examples 
 #' \dontrun{
@@ -41,6 +43,7 @@ spacy_install <- function(conda = "auto",
                           version = "latest",
                           lang_models = "en",
                           python_version = "3.6",
+                          envname = "spacy_condaenv",
                           python_path = NULL, 
                           prompt = TRUE) {
     # verify os
@@ -83,7 +86,8 @@ spacy_install <- function(conda = "auto",
             }
             
             # do install
-            process_spacy_installation_conda(conda, version, lang_models, python_version, prompt)
+            process_spacy_installation_conda(conda, version, lang_models, python_version, prompt, 
+                                             envname = envname)
 
     # windows installation
     } else {
@@ -107,7 +111,8 @@ spacy_install <- function(conda = "auto",
         }
         
         # do the install
-        process_spacy_installation_conda(conda, version, lang_models, python_version, prompt)
+        process_spacy_installation_conda(conda, version, lang_models, python_version, prompt,
+                                         envname = envname)
              
     }
     cat("\nInstallation complete.\n\n")
@@ -224,13 +229,13 @@ spacy_install_virtualenv <- function(version = "latest",
 
 
 process_spacy_installation_conda <- function(conda, version, lang_models, python_version, 
-                                             prompt = TRUE) {
+                                             prompt = TRUE,
+                                             envname = "spacy_condaenv") {
     
-    # create conda environment if we need to
-    envname <- "spacy_condaenv"
+    
     conda_envs <- reticulate::conda_list(conda = conda)
     if (prompt) {
-        cat("A new conda environment \"spacy_condaenv\" will be created and \nspaCy and language model(s):", 
+        cat("A new conda environment", paste0('"', envname ,'"'), "will be created and \nspaCy and language model(s):", 
                 paste(lang_models, collapse = ", "), "will be installed.  ")
         ans <- utils::menu(c("No", "Yes"), title = "Proceed?")
         if (ans == 1) stop("condaenv setup is cancelled by user", call. = FALSE)
@@ -283,7 +288,8 @@ process_spacy_installation_conda <- function(conda, version, lang_models, python
     packages <- spacy_pkgs(version)
     reticulate::conda_install(envname, packages, pip = TRUE, conda = conda)
     
-    for(model in lang_models) spacy_download_langmodel(model = model, conda = conda)
+    for(model in lang_models) spacy_download_langmodel(model = model, conda = conda,
+                                                       envname = envname)
     
 }
 

--- a/R/spacy_install.R
+++ b/R/spacy_install.R
@@ -32,7 +32,9 @@
 #'   automatically find the path
 #' @param lang_models character; language models to be installed. Default
 #'   \code{en} (English model). A vector of multiple model names can be used
-#'   (e.g. \code{c("en", "de")})
+#'   (e.g. \code{c("en", "de")}).  A list of available language models and their
+#'   names is available from the \href{https://spacy.io/usage/models}{spaCy
+#'   language models} page.
 #' @param version character; spaCy version to install. Specify \code{"latest"}
 #'   to install the latest release, or \code{"latest_v1"} to install the latest 
 #'   release of spacy v1.*.  See spaCy Version Issues.
@@ -59,22 +61,22 @@ spacy_install <- function(conda = "auto",
                           lang_models = "en",
                           python_version = "3.6",
                           envname = "spacy_condaenv",
-                          python_path = NULL, 
+                          python_path = NULL,
                           prompt = TRUE) {
     # verify os
     if (!is_windows() && !is_osx() && !is_linux()) {
         stop("This function is available only for Windows, Mac, and Linux")
     }
-    
+
     # verify 64-bit
     # if (.Machine$sizeof.pointer != 8) {
     #     stop("Unable to install TensorFlow on this platform.",
     #          "Binary installation is only available for 64-bit platforms.")
     # }
-    # 
-    
-    if(!(identical(version, "latest") || identical(version, "latest_v1"))) {
-        if(!(grepl("(\\d+\\.){1,2}(\\d+)?", version))){
+    #
+
+    if (!(identical(version, "latest") || identical(version, "latest_v1"))) {
+        if (!(grepl("(\\d+\\.){1,2}(\\d+)?", version))){
             stop("spacy version specification error\n",
                  "Please provide a full major.minor.patch specification",
                  call. = FALSE)
@@ -84,10 +86,10 @@ spacy_install <- function(conda = "auto",
     # resolve and look for conda
     conda <- tryCatch(reticulate::conda_binary(conda), error = function(e) NULL)
     have_conda <- !is.null(conda)
-    
+
     # mac and linux
     if (is_unix()) {
-        
+
         # check for explicit conda method
 
             # validate that we have conda
@@ -96,27 +98,26 @@ spacy_install <- function(conda = "auto",
                 ans <- utils::menu(c("No", "Yes"), title = "Do you want spacyr to download miniconda in ~/miniconda?")
                 if (ans == 2) {
                   install_miniconda()
-                  conda <- tryCatch(reticulate::conda_binary('auto'), error = function(e) NULL)
+                  conda <- tryCatch(reticulate::conda_binary("auto"), error = function(e) NULL)
                 } else stop("Conda environment installation failed (no conda binary found)\n", call. = FALSE)
             }
-            
+
             # do install
-            process_spacy_installation_conda(conda, version, lang_models, python_version, prompt, 
+            process_spacy_installation_conda(conda, version, lang_models, python_version, prompt,
                                              envname = envname)
 
     # windows installation
     } else {
-        
+
         # determine whether we have system python
         python_versions <- reticulate::py_versions_windows()
-        python_versions <- python_versions[python_versions$type == "PythonCore",]
-        python_versions <- python_versions[python_versions$version %in% c("3.5","3.6"),]
-        python_versions <- python_versions[python_versions$arch == "x64",]
+        python_versions <- python_versions[python_versions$type == "PythonCore", ]
+        python_versions <- python_versions[python_versions$version %in% c("3.5", "3.6"), ]
+        python_versions <- python_versions[python_versions$arch == "x64", ]
         have_system <- nrow(python_versions) > 0
         if (have_system)
-            python_system_version <- python_versions[1,]
-        
-        
+            python_system_version <- python_versions[1, ]
+
         # validate that we have conda
         if (!have_conda) {
             stop("Conda installation failed (no conda binary found)\n\n",
@@ -124,15 +125,15 @@ spacy_install <- function(conda = "auto",
                  "before installing spaCy",
                  call. = FALSE)
         }
-        
+
         # do the install
         process_spacy_installation_conda(conda, version, lang_models, python_version, prompt,
                                          envname = envname)
-             
+ 
     }
     message("\nInstallation complete.\n",
             sprintf("Condaenv: %s; Langage model(s):", envname), lang_models, "\n")
-    
+
     invisible(NULL)
 }
 
@@ -148,45 +149,45 @@ spacy_install <- function(conda = "auto",
 spacy_install_virtualenv <- function(version = "latest",
                                      lang_models = "en",
                                      python_version = "3.6",
-                                     python_path = NULL, 
+                                     python_path = NULL,
                                      prompt = TRUE) {
     # verify os
     if (!is_osx() && !is_linux()) {
         stop("This function is available only for Mac and Linux", call. = FALSE)
     }
-    
+
     # if (identical(method, "virtualenv") && is_windows()) {
     #     stop("Installing spaCy into a virtualenv is not supported on Windows",
     #          call. = FALSE)
     # }
-    
+
     # unroll version
     # ver <- parse_spacy_version(version)
     # version <- ver$version
 
-    if(!(identical(version, "latest") || identical(version, "latest_v1"))) {
-        if(!(grepl("(\\d+\\.){1,2}(\\d+)?", version))){
+    if (!(identical(version, "latest") || identical(version, "latest_v1"))) {
+        if (!(grepl("(\\d+\\.){1,2}(\\d+)?", version))){
             stop("spacy version specification error\n",
                  "Please provide a full major.minor.patch specification",
                  call. = FALSE)
         }
     }
-    
+
     # mac and linux
 
     # check for explicit conda method
-    
+
     # find system python binary
-    python <- if(!is.null(python_path)) python_path else python_unix_binary("python")
+    python <- if (!is.null(python_path)) python_path else python_unix_binary("python")
     if (is.null(python))
         stop("Unable to locate Python on this system.", call. = FALSE)
-    
+
     # find other required tools
     pip <- python_unix_binary("pip")
     have_pip <- !is.null(pip)
     virtualenv <- python_unix_binary("virtualenv")
     have_virtualenv <- !is.null(virtualenv)
-    
+
     # stop if either pip or virtualenv is not available
     if (!have_pip || !have_virtualenv) {
         install_commands <- NULL
@@ -220,7 +221,7 @@ spacy_install_virtualenv <- function(version = "latest",
             }
         }
         if (!is.null(install_commands)) {
-            
+
             # if these are terminal commands then add special preface
             if (grepl("^\\$ ", install_commands)) {
                 install_commands <- paste0(
@@ -228,35 +229,34 @@ spacy_install_virtualenv <- function(version = "latest",
                     install_commands
                 )
             }
-            
+
             stop("Prerequisites for installing spaCy not available.\n\n",
                  install_commands, "\n\n", call. = FALSE)
         }
     }
-    process_spacy_installation_virtualenv(python, virtualenv, version, lang_models, prompt)       
-    
+    process_spacy_installation_virtualenv(python, virtualenv, version, lang_models, prompt)     
+
     cat("\nInstallation complete.\n\n")
-    
+
     # if (restart_session && rstudioapi::hasFun("restartSession"))
     #     rstudioapi::restartSession()
-    
+
     invisible(NULL)
 }
 
 
 
-process_spacy_installation_conda <- function(conda, version, lang_models, python_version, 
+process_spacy_installation_conda <- function(conda, version, lang_models, python_version,
                                              prompt = TRUE,
                                              envname = "spacy_condaenv") {
-    
-    
+
     conda_envs <- reticulate::conda_list(conda = conda)
     if (prompt) {
-        cat("A new conda environment", paste0('"', envname ,'"'), "will be created and \nspaCy and language model(s):", 
+        cat("A new conda environment", paste0('"', envname, '"'), "will be created and \nspaCy and language model(s):",
                 paste(lang_models, collapse = ", "), "will be installed.  ")
         ans <- utils::menu(c("No", "Yes"), title = "Proceed?")
         if (ans == 1) stop("condaenv setup is cancelled by user", call. = FALSE)
-    }  
+    }
     conda_env <- subset(conda_envs, conda_envs$name == envname)
     if (nrow(conda_env) == 1) {
         cat("Using", envname, "conda environment for spaCy installation\n")
@@ -264,11 +264,11 @@ process_spacy_installation_conda <- function(conda, version, lang_models, python
     }
     else {
         cat("Creating", envname, "conda environment for spaCy installation...\n")
-        python_packages <- ifelse(is.null(python_version), "python=3.6", 
+        python_packages <- ifelse(is.null(python_version), "python=3.6",
                                   sprintf("python=%s", python_version))
         python <- reticulate::conda_create(envname, packages = python_packages, conda = conda)
     }
-    
+
     # Short circuit to install everything with conda when no custom packages
     # (typically tf-nightly or a daily build URL) and no gpu-enabled build
     # is requested (conda doesn't currently have GPU enabled builds.
@@ -298,9 +298,9 @@ process_spacy_installation_conda <- function(conda, version, lang_models, python
     #     )
     #     return(invisible(NULL))
     # }
-    # 
-    
-    # this function generates a forced pip error to get a version spacy highest within a major version 
+    #
+
+    # this function generates a forced pip error to get a version spacy highest within a major version
     # e.g. if major_version == 1, it will return 1.10.1
     pip_get_version_conda <- function(major_version) {
         condaenv_bin <- function(bin) path.expand(file.path(dirname(conda), bin))
@@ -308,24 +308,24 @@ process_spacy_installation_conda <- function(conda, version, lang_models, python
                        ifelse(is_windows(), "", ifelse(is_osx(), "source ", "/bin/bash -c \"source ")),
                        shQuote(path.expand(condaenv_bin("activate"))),
                        envname,
-                       "--ignore-installed", 
+                       "--ignore-installed",
                        paste(shQuote("spacy==random"), collapse = " "),
                        ifelse(is_windows(), "", ifelse(is_osx(), "", "\"")))
         pip_get_version(cmd = cmd, major_version = major_version)
     }
-    
+
     # install base spaCy using pip
-    if(version == "latest_v1") {
+    if (version == "latest_v1") {
         version <- pip_get_version_conda(1)
-        cat('Option "version = version_v1" is supplied, spacy', version, 'will be isntalled\n')
+        cat("Option \"version = version_v1\" is supplied, spaCy", version, "will be installed\n")
     }
-    cat("Installing Spacy...\n")
+    cat("Installing spaCy...\n")
     packages <- spacy_pkgs(version)
     reticulate::conda_install(envname, packages, pip = TRUE, conda = conda)
-    
-    for(model in lang_models) spacy_download_langmodel(model = model, conda = conda,
+
+    for (model in lang_models) spacy_download_langmodel(model = model, conda = conda,
                                                        envname = envname)
-    
+
 }
 
 
@@ -349,24 +349,22 @@ process_spacy_installation_conda <- function(conda, version, lang_models, python
 
 
 process_spacy_installation_virtualenv <- function(python, virtualenv, version, lang_models, prompt = TRUE) {
-    
+
     # determine python version to use
     is_python3 <- python_version(python) >= "3.0"
-    if(!is_python3) {
+    if (!is_python3) {
         stop("spacyr does not support virtual environment installation for python 2.*", call. = FALSE)
     }
     pip_version <- ifelse(is_python3, "pip3", "pip")
-    
 
-    
     virtualenv_root <- Sys.getenv("WORKON_HOME", unset = "~/.virtualenvs")
     virtualenv_path <- file.path(virtualenv_root, "spacy_virtualenv")
 
     if (prompt) {
-        cat(sprintf('A new virtual environment "%s" will be created and, \nspaCy and language model(s), "%s", will be installed.\n ', 
-                    virtualenv_path, 
+        cat(sprintf('A new virtual environment "%s" will be created and, \nspaCy and language model(s), "%s", will be installed.\n ',
+                    virtualenv_path,
                     paste(lang_models, collapse = ", ")))
-        
+    
         ans <- utils::menu(c("No", "Yes"), title = "Proceed?")
         if (ans == 1) stop("Virtualenv setup is cancelled by user", call. = FALSE)
     }
@@ -374,10 +372,10 @@ process_spacy_installation_virtualenv <- function(python, virtualenv, version, l
     # create virtualenv
     if (!file.exists(virtualenv_root))
         dir.create(virtualenv_root, recursive = TRUE)
-    
+
     # helper to construct paths to virtualenv binaries
     virtualenv_bin <- function(bin) path.expand(file.path(virtualenv_path, "bin", bin))
-    
+
     # create virtualenv if necessary
     if (!file.exists(virtualenv_path) || !file.exists(virtualenv_bin("activate"))) {
         cat("Creating virtualenv for spaCy at ", virtualenv_path, "\n")
@@ -392,7 +390,7 @@ process_spacy_installation_virtualenv <- function(python, virtualenv, version, l
     } else {
         cat("Using existing virtualenv at ", virtualenv_path, "\n")
     }
-    
+
     # function to call pip within virtual env
     pip_install <- function(pkgs, message) {
         cmd <- sprintf("%ssource %s && %s install --ignore-installed --upgrade %s%s",
@@ -406,8 +404,8 @@ process_spacy_installation_virtualenv <- function(python, virtualenv, version, l
         if (result != 0L)
             stop("Error ", result, " occurred installing spaCy", call. = FALSE)
     }
-    
-    # this function generates a forced pip error to get a version spacy highest within a major version 
+
+    # this function generates a forced pip error to get a version spacy highest within a major version
     # e.g. if major_version == 1, it will return 1.10.1
     pip_get_version_virtualenv <- function(major_version) {
         cmd <- sprintf("%ssource %s && %s install --ignore-installed --upgrade %s%s",
@@ -418,25 +416,24 @@ process_spacy_installation_virtualenv <- function(python, virtualenv, version, l
                        ifelse(is_osx(), "", "\""))
         pip_get_version(cmd, major_version)
     }
-    
+
     # upgrade pip so it can find spaCy
     pip_install("pip", "Upgrading pip")
-    
+
     # install updated version of the wheel package
     pip_install("wheel", "Upgrading wheel")
-    
+
     # upgrade setuptools so it can use wheels
     pip_install("setuptools", "Upgrading setuptools")
-    
-    
-    if(version == "latest_v1") {
+
+    if (version == "latest_v1") {
         version <- pip_get_version_virtualenv(1, major_version = 1)
-        cat('Option "version = version_v1" is supplied, spacy', version, 'will be isntalled\n')
+        cat("Option \"version = version_v1\" is supplied, spaCy", version, "will be installed\n")
     }
     pkgs <- spacy_pkgs(version)
     pip_install(pkgs, "Installing spaCy...")
-    
-    for(model in lang_models) {
+
+    for (model in lang_models) {
         spacy_download_langmodel_virtualenv(model = model)
     }
 }
@@ -451,21 +448,21 @@ python_unix_binary <- function(bin) {
 }
 
 python_version <- function(python) {
-    
+
     # check for the version
     result <- system2(python, "--version", stdout = TRUE, stderr = TRUE)
-    
+
     # check for error
     error_status <- attr(result, "status")
     if (!is.null(error_status))
         stop("Error ", error_status, " occurred while checking for python version", call. = FALSE)
-    
+
     # parse out the major and minor version numbers
     matches <- regexec("^[^ ]+\\s+(\\d+)\\.(\\d+).*$", result)
     matches <- regmatches(result, matches)[[1]]
     if (length(matches) != 3)
         stop("Unable to parse Python version '", result[[1]], "'", call. = FALSE)
-    
+
     # return as R numeric version
     numeric_version(paste(matches[[2]], matches[[3]], sep = "."))
 }
@@ -491,7 +488,7 @@ spacy_uninstall <- function(conda = "auto",
                             envname = "spacy_condaenv") {
     conda <- tryCatch(reticulate::conda_binary(conda), error = function(e) NULL)
     have_conda <- !is.null(conda)
-    
+
     if (!have_conda)
         stop("Conda installation failed (no conda binary found)\n", call. = FALSE)
 
@@ -506,9 +503,8 @@ spacy_uninstall <- function(conda = "auto",
     python <- reticulate::conda_remove(envname = envname)
 
     cat("\nUninstallation complete.\n\n")
-    
-    invisible(NULL)
 
+    invisible(NULL)
 }
 
 
@@ -529,12 +525,11 @@ spacy_upgrade  <- function(conda = "auto",
     
     message("checking spaCy version")
     conda <- reticulate::conda_binary(conda)
-    if(!(envname %in% reticulate::conda_list(conda = conda)$name)) {
+    if (!(envname %in% reticulate::conda_list(conda = conda)$name)) {
         message("Conda evnronment", envname ,"does not exist")
         
     }
 
-    # 
     condaenv_bin <- function(bin) path.expand(file.path(dirname(conda), bin))
     
     cmd <- sprintf("%s%s %s && pip search spacy",
@@ -543,25 +538,25 @@ spacy_upgrade  <- function(conda = "auto",
                    envname,
                    ifelse(is_windows(), "", ifelse(is_osx(), "", "\"")))
     result <- system(cmd, intern = TRUE, ignore.stderr = TRUE)
-    spacy_index <- grep("spacy \\(" , result)
+    spacy_index <- grep("spacy \\(", result)
     latest_spacy <- sub("spacy \\((.+?)\\).+", "\\1", result[spacy_index])
     installed_spacy <- sub(".+?(\\d.+\\d).*", "\\1", result[spacy_index + 1])
-    if(latest_spacy == installed_spacy) {
+    if (latest_spacy == installed_spacy) {
         message("your spaCy is up-to-date")
         return(invisible(NULL))
-    } else if(substr(installed_spacy, 0, 2) == "1."){
+    } else if (substr(installed_spacy, 0, 2) == "1."){
         cat(sprintf("The version spacy installed is %s\n", 
                     installed_spacy)) 
         ans <- utils::menu(c("v1.*", "v2.*"), title = sprintf('Do you want to upgrade to v1.* or lastest v2.*?'))
-        if(ans == 2) {
-            cat('Spacy will be upgraded version', latest_spacy,'\n')
+        if (ans == 2) {
+            cat('spaCy will be upgraded to version', latest_spacy,'\n')
             process_spacy_installation_conda(conda = conda, 
                                              envname = envname,
                                              version = "latest", 
                                              lang_models = lang_models, 
                                              python_version = "3.6", 
                                              prompt = FALSE)
-        } else{
+        } else {
             cmd <- sprintf("%s%s %s && pip install --upgrade %s %s%s",
                            ifelse(is_windows(), "", ifelse(is_osx(), "source ", "/bin/bash -c \"source ")),
                            shQuote(path.expand(condaenv_bin("activate"))),
@@ -571,11 +566,11 @@ spacy_upgrade  <- function(conda = "auto",
                            ifelse(is_windows(), "", ifelse(is_osx(), "", "\"")))
             
             latest_spacy_v1 <- pip_get_version(cmd, major_version = 1)
-            if(latest_spacy_v1 == installed_spacy){
+            if (latest_spacy_v1 == installed_spacy){
                 message("your spaCy is the latest v1")
                 return(invisible(NULL))
             } else {
-                
+
                 cat(sprintf("A new version of spacy v1 (%s) will be installed (installed version: %s)\n", 
                             latest_spacy_v1, installed_spacy))
                 process_spacy_installation_conda(conda = conda, 
@@ -589,13 +584,13 @@ spacy_upgrade  <- function(conda = "auto",
     } else {
         cat(sprintf("A new version of spacy (%s) was found (installed version: %s)\n", 
                     latest_spacy, installed_spacy))
-        ans <- utils::menu(c("No", "Yes"), title = sprintf('Do you want to upgrade?'))
-        if(ans == 2) {
-            cat('"Yes" was chosen. Spacy will be upgraded.\n\n')
-            if(!is.null(lang_models)){
+        ans <- utils::menu(c("No", "Yes"), title = sprintf("Do you want to upgrade?"))
+        if (ans == 2) {
+            cat('"Yes" was chosen. spaCy will be upgraded.\n\n')
+            if (!is.null(lang_models)) {
                 ans <- utils::menu(c("No", "Yes"), title = sprintf("Do you also want to re-download language model %s?", 
                                                                    paste(lang_models, collapse = ", ")))
-                if(ans == 1) lang_models <- NULL
+                if (ans == 1) lang_models <- NULL
             }
             process_spacy_installation_conda(conda = conda, 
                                              envname = envname,
@@ -613,7 +608,7 @@ spacy_upgrade  <- function(conda = "auto",
 }
 
 install_miniconda <- function() {
-    if(is_osx()) {
+    if (is_osx()) {
         message("Downloading installation script")
         system(paste(
             'curl https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o ~/miniconda.sh;',
@@ -621,7 +616,7 @@ install_miniconda <- function() {
             'bash ~/miniconda.sh -b -p $HOME/miniconda'))
         system('echo \'export PATH="$PATH:$HOME/miniconda/bin"\' >> $HOME/.bash_profile; rm ~/miniconda.sh')
         message("Installation of miniconda complete")
-    } else if(is_linux()) {
+    } else if (is_linux()) {
         message("Downloading installation script")
         system(paste(
             'wget -nv https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh;',
@@ -705,4 +700,3 @@ pip_get_version <- function(cmd, major_version) {
 #         stop("Error ", result, " occurred installing tensorflow package", call. = FALSE)
 # }
 # 
-

--- a/R/spacy_langmodel_functions.R
+++ b/R/spacy_langmodel_functions.R
@@ -10,7 +10,7 @@
 spacy_download_langmodel <- function(model = "en",
                                      envname = "spacy_condaenv", 
                                      conda = "auto") {
-    message(sprintf("installing model \"%s\"\n", model))
+    message(sprintf("Installing model \"%s\"\n", model))
     # resolve conda binary
     conda <- reticulate::conda_binary(conda)
     
@@ -29,7 +29,7 @@ spacy_download_langmodel <- function(model = "en",
         stop("Error ", result, " occurred installing packages into conda environment ", 
              envname, call. = FALSE)
     }
-    
+    message(sprintf("Language model \"%s\" is successfully installed\n", model))
     invisible(NULL)
 }
 

--- a/R/spacy_langmodel_functions.R
+++ b/R/spacy_langmodel_functions.R
@@ -67,6 +67,7 @@ spacy_download_langmodel_virtualenv <- function(model = "en",
         stop("Error ", result, " occurred installing packages into virtual environment ", 
              envname, call. = FALSE)
     }
+    message(sprintf("Language model \"%s\" is successfully installed\n", model))
     
     invisible(NULL)
 }

--- a/R/spacy_langmodel_functions.R
+++ b/R/spacy_langmodel_functions.R
@@ -5,7 +5,9 @@
 #' @param envname name of the virtual environment
 #' @param conda Path to conda executable.  Default \code{"auto"} which
 #'   automatically finds the path.
-#' @param model name of the language model to be installed
+#' @param model name of the language model to be installed.  A list of available
+#'   language models and their names is available from the
+#'   \href{https://spacy.io/usage/models}{spaCy language models} page.
 #' @export
 spacy_download_langmodel <- function(model = "en",
                                      envname = "spacy_condaenv", 

--- a/man/spacy_download_langmodel.Rd
+++ b/man/spacy_download_langmodel.Rd
@@ -12,7 +12,9 @@ spacy_download_langmodel_virtualenv(model = "en",
   envname = "spacy_virtualenv", virtualenv_root = NULL)
 }
 \arguments{
-\item{model}{name of the language model to be installed}
+\item{model}{name of the language model to be installed.  A list of available
+language models and their names is available from the
+\href{https://spacy.io/usage/models}{spaCy language models} page.}
 
 \item{envname}{name of the virtual environment}
 

--- a/man/spacy_install.Rd
+++ b/man/spacy_install.Rd
@@ -6,7 +6,8 @@
 \title{Install spaCy in conda or virtualenv environment}
 \usage{
 spacy_install(conda = "auto", version = "latest", lang_models = "en",
-  python_version = "3.6", python_path = NULL, prompt = TRUE)
+  python_version = "3.6", envname = "spacy_condaenv", python_path = NULL,
+  prompt = TRUE)
 
 spacy_install_virtualenv(version = "latest", lang_models = "en",
   python_version = "3.6", python_path = NULL, prompt = TRUE)
@@ -26,6 +27,9 @@ automatically find the path}
 
 \item{python_version}{character; determine Python version for condaenv
 installation. 3.5 and 3.6 are available.}
+
+\item{envname}{character; name of the conda-environment to install spacy. 
+Default is "spacy_condaenv".}
 
 \item{python_path}{character; path to Python in virtualenv installation}
 

--- a/man/spacy_install.Rd
+++ b/man/spacy_install.Rd
@@ -24,7 +24,9 @@ automatically find the path}
 
 \item{lang_models}{character; language models to be installed. Default
 \code{en} (English model). A vector of multiple model names can be used
-(e.g. \code{c("en", "de")})}
+(e.g. \code{c("en", "de")}).  A list of available language models and their
+names is available from the \href{https://spacy.io/usage/models}{spaCy
+language models} page.}
 
 \item{python_version}{character; determine Python version for condaenv
 installation. 3.5 and 3.6 are available.}

--- a/man/spacy_install.Rd
+++ b/man/spacy_install.Rd
@@ -45,6 +45,14 @@ Install spaCy in a self-contained environment, including
   locate and use an existing installation automatically, or download and
   install one if none exists.  The miniconda installation is not currently
   available on Windows.
+  
+  Regarding the installation option, \code{version="latest_v1"}. At the moment, 
+  there is a performance issue for spaCy pipeline for spacy v2.*. And that affect
+  the performance of \code{spacy_parse()} especially when a large number of 
+  small texts are parseed. For this reason, the package \code{spacyr}
+  provides an option to automatically install the latest version of spacy v1.*.
+  
+  The details of this performance issue are available at spaCy issue \href{https://github.com/explosion/spaCy/issues/1508}{#1508: v2 standard pipeline running 10x slower}
 
 If you wish to install Python ion a "virtualenv", use the
   \code{spacy_install_virtualenv} function.

--- a/man/spacy_install.Rd
+++ b/man/spacy_install.Rd
@@ -18,7 +18,7 @@ automatically find the path}
 
 \item{version}{character; spaCy version to install. Specify \code{"latest"}
   to install the latest release, or \code{"latest_v1"} to install the latest 
-  release of spacy v1.*
+  release of spacy v1.*.  See spaCy Version Issues.
 
   You can also provide a full major.minor.patch specification (e.g. "1.1.0")}
 
@@ -43,20 +43,28 @@ Install spaCy in a self-contained environment, including
   \code{spacy_install}.  Alternatively, an existing conda installation may be
   used, by specifying its path.  The default setting of \code{"auto"} will
   locate and use an existing installation automatically, or download and
-  install one if none exists.  The miniconda installation is not currently
-  available on Windows.
+  install one if none exists.  
   
-  Regarding the installation option, \code{version="latest_v1"}. At the moment, 
-  there is a performance issue for spaCy pipeline for spacy v2.*. This can  enormously 
-  affect the performance of \code{spacy_parse()}, especially when a large number of 
-  small texts are parseed. For this reason, the package \code{spacyr}
-  provides an option to automatically install the latest version of spacy v1.*.
-  
-  The details of this performance issue are available at spaCy issue \href{https://github.com/explosion/spaCy/issues/1508}{#1508: v2 standard pipeline running 10x slower}
+  For Windows, automatic installation of miniconda installation is not currently
+  available, so the user will need to \href{https://conda.io/docs/user-guide/install/windows.html}{miniconda (or Anaconda) manually}.
 
 If you wish to install Python ion a "virtualenv", use the
   \code{spacy_install_virtualenv} function.
 }
+\section{spaCy Version Issues}{
+
+
+  The version options currently default to the latest spaCy v2 (\code{version
+  = "latest"}). As of 2018-04, however,
+  \href{https://github.com/explosion/spaCy/issues/1508}{some performance
+  issues} affect the speed of the spaCy pipeline for spacy v2.x relative to
+  v1.x.   This can  enormously affect the performance of
+  \code{spacy_parse()}, especially when a large number of small texts are
+  parseed. For this reason, the \pkg{spacyr} provides an option to
+  automatically install the latest version of spacy v1.*, using \code{version
+  = "latest_v1"}.
+}
+
 \examples{
 \dontrun{
 # install spaCy in a miniconda environment (macOS and Linux)

--- a/man/spacy_install.Rd
+++ b/man/spacy_install.Rd
@@ -47,8 +47,8 @@ Install spaCy in a self-contained environment, including
   available on Windows.
   
   Regarding the installation option, \code{version="latest_v1"}. At the moment, 
-  there is a performance issue for spaCy pipeline for spacy v2.*. And that affect
-  the performance of \code{spacy_parse()} especially when a large number of 
+  there is a performance issue for spaCy pipeline for spacy v2.*. This can  enormously 
+  affect the performance of \code{spacy_parse()}, especially when a large number of 
   small texts are parseed. For this reason, the package \code{spacyr}
   provides an option to automatically install the latest version of spacy v1.*.
   

--- a/man/spacy_install.Rd
+++ b/man/spacy_install.Rd
@@ -17,7 +17,8 @@ spacy_install_virtualenv(version = "latest", lang_models = "en",
 automatically find the path}
 
 \item{version}{character; spaCy version to install. Specify \code{"latest"}
-  to install the latest release.
+  to install the latest release, or \code{"latest_v1"} to install the latest 
+  release of spacy v1.*
 
   You can also provide a full major.minor.patch specification (e.g. "1.1.0")}
 

--- a/man/spacy_uninstall.Rd
+++ b/man/spacy_uninstall.Rd
@@ -4,13 +4,13 @@
 \alias{spacy_uninstall}
 \title{Unnstall spaCy conda environment}
 \usage{
-spacy_uninstall(conda = "auto", prompt = TRUE)
+spacy_uninstall(conda = "auto", envname = "spacy_condaenv")
 }
 \arguments{
 \item{conda}{Path to conda executable. Default "auto" which automatically
 find the path}
 
-\item{prompt}{logical; ask whether proceed during the installation}
+\item{envname}{character; name of conda environent to remove}
 }
 \description{
 Removes the conda environemnt craeted by spacy_install()

--- a/man/spacy_upgrade.Rd
+++ b/man/spacy_upgrade.Rd
@@ -4,11 +4,14 @@
 \alias{spacy_upgrade}
 \title{Install spaCy in conda environment}
 \usage{
-spacy_upgrade(conda = "auto", lang_models = NULL)
+spacy_upgrade(conda = "auto", envname = "spacy_condaenv",
+  lang_models = "en")
 }
 \arguments{
 \item{conda}{Path to conda executable. Default "auto" which automatically
 find the path}
+
+\item{envname}{character; name of conda environment to upgrate spaCy}
 
 \item{lang_models}{Language models to be upgraded. Default NULL (No upgrade). 
 A vector of multiple model names can be used (e.g. \code{c("en", "de")})}

--- a/tests/misc/note_performance_issues.Rmd
+++ b/tests/misc/note_performance_issues.Rmd
@@ -1,0 +1,28 @@
+---
+title: "Notes on Performance Issue in spacy v2.*"
+author: "Akitaka Matsuo"
+date: "4/9/2018"
+output: html_document
+---
+
+
+It's a known issue
+
+## https://github.com/explosion/spaCy/issues/1508
+
+- OpenBLAS version
+    - (Linux) ldd `python -c "import numpy.core; print(numpy.core.multiarray.__file__)"`
+    - (Mac) otool -L `python -c "import numpy.core; print(numpy.core.multiarray.__file__)"`
+
+
+- https://github.com/explosion/spaCy/issues/2032
+    - (https://github.com/explosion/spaCy/issues/2038)
+- https://github.com/explosion/spaCy/issues/2098
+
+
+## Parallel processing
+- [Advice for parallel processing](https://github.com/explosion/spaCy/issues/1839)
+- https://medium.com/@vishnups/speeding-up-spacy-f766e3dd033c
+
+
+

--- a/tests/misc/note_performance_issues.Rmd
+++ b/tests/misc/note_performance_issues.Rmd
@@ -6,21 +6,63 @@ output: html_document
 ---
 
 
-It's a known issue
+## It's a known issue
 
-## https://github.com/explosion/spaCy/issues/1508
-
-- OpenBLAS version
-    - (Linux) ldd `python -c "import numpy.core; print(numpy.core.multiarray.__file__)"`
-    - (Mac) otool -L `python -c "import numpy.core; print(numpy.core.multiarray.__file__)"`
+### https://github.com/explosion/spaCy/issues/1508
 
 
+### Some performance testing
+
+
+#### preparation in R
+- the latest of `performance-issue-explore` has the functionality of install different version of spacy under different envname 
+
+```{r eval = FALSE}
+library(spacyr)
+spacy_install(envname = "spacy_condaenv_latest")
+spacy_install(envname = "spacy_condaenv_v1.10.0", version = "1.10.0")
+```
+
+#### run a test in `tests/misc/py_scripts`
+
+##### with the latest spaCy (v2.0.11)
+```
+(spacy_condaenv_latest) KBsiMacHome:py_script akitaka$ python benchmark_small_docs.py
+version= 2.0 components= ['tagger', 'parser', 'ner'] disabled= [] use_pipe= 0 wps= 1107.689528844235 words= 58685 seconds= 52.979646797990426
+version= 2.0 components= ['tagger', 'parser', 'ner'] disabled= [] use_pipe= 1 wps= 4454.833333644159 words= 58032 seconds= 13.026749971031677
+version= 2.0 components= ['tagger'] disabled= ['parser', 'ner'] use_pipe= 0 wps= 3575.6897783679424 words= 65120 seconds= 18.211870726023335
+version= 2.0 components= ['tagger'] disabled= ['parser', 'ner'] use_pipe= 1 wps= 15920.57125097865 words= 57842 seconds= 3.63316109002335
+version= 2.0 components= ['tagger', 'ner'] disabled= ['parser'] use_pipe= 0 wps= 1712.7799061057126 words= 56324 seconds= 32.88455206603976
+version= 2.0 components= ['tagger', 'ner'] disabled= ['parser'] use_pipe= 1 wps= 7446.164664864156 words= 63919 seconds= 8.584150751004927
+```
+
+##### with spacy v1.10.0 (testscript: `test_v1.10.sh`)
+```
+version= 1.10 components= ['tagger', 'parser', 'ner'] disabled= [] use_pipe= 1 wps= 23226.304570550397 words= 63005 seconds= 2.712657099997159
+version= 1.10 components= ['tagger'] disabled= ['ner', 'parser'] use_pipe= 0 wps= 61613.47611414316 words= 57083 seconds= 0.9264693959848955
+version= 1.10 components= ['tagger'] disabled= ['ner', 'parser'] use_pipe= 1 wps= 66882.46893803598 words= 59783 seconds= 0.8938515720074065
+version= 1.10 components= ['tagger', 'ner'] disabled= ['parser'] use_pipe= 0 wps= 42365.39600838973 words= 55532 seconds= 1.3107867559883744
+version= 1.10 components= ['tagger', 'ner'] disabled= ['parser'] use_pipe= 1 wps= 41980.147682750954 words= 54079 seconds= 1.2882041389821097
+```
+
+#### Verdict
+
+- v2 is quite slow especially without parallel (using `pipe`)
+- parallelazation makes both v2 and v2 faster
+
+## Plan of Attack?
+
+- For the short time period, we chould add note on spaCy v2
+- Also, we should work on the implementation of proper pipe for spacy v2, and hopefully get it done by textworkshop18
+
+
+## other issues to refer
 - https://github.com/explosion/spaCy/issues/2032
     - (https://github.com/explosion/spaCy/issues/2038)
 - https://github.com/explosion/spaCy/issues/2098
 
 
-## Parallel processing
+## Parallel processing references
 - [Advice for parallel processing](https://github.com/explosion/spaCy/issues/1839)
 - https://medium.com/@vishnups/speeding-up-spacy-f766e3dd033c
 

--- a/tests/misc/py_script/benchmark_small_docs.py
+++ b/tests/misc/py_script/benchmark_small_docs.py
@@ -1,0 +1,40 @@
+from timeit import default_timer as timer
+import spacy
+import thinc.extra.datasets
+import plac
+
+
+def iter_phrases(texts):
+    for text in texts:
+        for i in range(0, len(text), 50):
+            yield text[i : i + 50]
+
+@plac.annotations(
+    components=("Pipeline components", "positional"),
+    use_pipe=("Whether to use nlp.pipe()", "flag", "p")
+)
+def main(components='tagger,parser,ner', use_pipe=False):
+    components = components.split(',')
+    use_pipe = int(use_pipe)
+    train, dev = thinc.extra.datasets.imdb()
+    texts, labels = zip(*train)
+    texts = texts[:200]
+    nlp = spacy.load('en_core_web_sm')
+    start = timer()
+    disabled = [name for name in nlp.pipe_names if name not in components]
+    with nlp.disable_pipes(*disabled):
+        n_words = 0
+        if use_pipe:
+            for doc in nlp.pipe(iter_phrases(texts)):
+                n_words += len(doc)
+        else:
+            for phrase in iter_phrases(texts):
+                doc = nlp(phrase)
+                n_words += len(doc)
+    seconds = timer() - start
+    wps = n_words / seconds
+    print('components=', components, 'disabled=', disabled, 'use_pipe=', use_pipe, 'wps=', wps,
+          'words=', n_words, 'seconds=', seconds)
+
+if __name__ == '__main__':
+    plac.call(main)

--- a/tests/misc/py_script/benchmark_small_docs.py
+++ b/tests/misc/py_script/benchmark_small_docs.py
@@ -1,3 +1,4 @@
+# this script is coming from https://github.com/explosion/spaCy/issues/1508#issuecomment-343007014
 from timeit import default_timer as timer
 import spacy
 import thinc.extra.datasets
@@ -5,36 +6,62 @@ import plac
 
 
 def iter_phrases(texts):
-    for text in texts:
-        for i in range(0, len(text), 50):
-            yield text[i : i + 50]
+	for text in texts:
+		for i in range(0, len(text), 50):
+			yield text[i : i + 50]
 
 @plac.annotations(
-    components=("Pipeline components", "positional"),
-    use_pipe=("Whether to use nlp.pipe()", "flag", "p")
+	components=("Pipeline components", "positional"),
+	use_pipe=("Whether to use nlp.pipe()", "flag", "p"),
+	version=("Is this version 1.9?","flag","v")
 )
-def main(components='tagger,parser,ner', use_pipe=False):
-    components = components.split(',')
-    use_pipe = int(use_pipe)
-    train, dev = thinc.extra.datasets.imdb()
-    texts, labels = zip(*train)
-    texts = texts[:200]
-    nlp = spacy.load('en_core_web_sm')
-    start = timer()
-    disabled = [name for name in nlp.pipe_names if name not in components]
-    with nlp.disable_pipes(*disabled):
-        n_words = 0
-        if use_pipe:
-            for doc in nlp.pipe(iter_phrases(texts)):
-                n_words += len(doc)
-        else:
-            for phrase in iter_phrases(texts):
-                doc = nlp(phrase)
-                n_words += len(doc)
-    seconds = timer() - start
-    wps = n_words / seconds
-    print('components=', components, 'disabled=', disabled, 'use_pipe=', use_pipe, 'wps=', wps,
-          'words=', n_words, 'seconds=', seconds)
+
+def main(components='tagger,parser,ner', use_pipe=False, version=False):
+	components = components.split(',')
+	use_pipe = int(use_pipe)
+	train, dev = thinc.extra.datasets.imdb()
+	texts, labels = zip(*train)
+	texts = texts[:200]
+	nlp = spacy.load('en')
+	start = timer()
+	
+	n_words = 0
+	
+	v = "2.0"
+	
+	if version:
+	
+		v = "1.10"
+		
+		disabled = [name for name in ['tagger','ner','parser'] 
+					if name not in components]
+	
+		nlp.pipeline = []
+		if 'tagger' in components:
+			nlp.pipeline.append(nlp.tagger)
+		if 'ner' in components:
+			nlp.pipeline.append(nlp.entity)
+		if 'parser' in components:
+			nlp.pipeline.append(nlp.parser)
+			
+	else:
+		disabled = [name for name in nlp.pipe_names if name not in components]
+		nlp.disable_pipes(*disabled)
+			
+	if use_pipe:
+		for doc in nlp.pipe(iter_phrases(texts)):
+			n_words += len(doc)
+	else:
+		for phrase in iter_phrases(texts):
+			doc = nlp(phrase)
+			n_words += len(doc)
+
+	seconds = timer() - start
+	wps = n_words / seconds
+	print('version=', v, 'components=', components, 'disabled=', disabled,
+		  'use_pipe=', use_pipe, 'wps=', wps, 'words=', n_words,
+		  'seconds=', seconds)
+
 
 if __name__ == '__main__':
-    plac.call(main)
+	plac.call(main)

--- a/tests/misc/py_script/benchmark_small_docs_bak.py
+++ b/tests/misc/py_script/benchmark_small_docs_bak.py
@@ -1,0 +1,40 @@
+from timeit import default_timer as timer
+import spacy
+import thinc.extra.datasets
+import plac
+
+
+def iter_phrases(texts):
+    for text in texts:
+        for i in range(0, len(text), 50):
+            yield text[i : i + 50]
+
+@plac.annotations(
+    components=("Pipeline components", "positional"),
+    use_pipe=("Whether to use nlp.pipe()", "flag", "p")
+)
+def main(components='tagger,parser,ner', use_pipe=False):
+    components = components.split(',')
+    use_pipe = int(use_pipe)
+    train, dev = thinc.extra.datasets.imdb()
+    texts, labels = zip(*train)
+    texts = texts[:200]
+    nlp = spacy.load('en')
+    start = timer()
+    disabled = [name for name in nlp.pipe_names if name not in components]
+    with nlp.disable_pipes(*disabled):
+        n_words = 0
+        if use_pipe:
+            for doc in nlp.pipe(iter_phrases(texts)):
+                n_words += len(doc)
+        else:
+            for phrase in iter_phrases(texts):
+                doc = nlp(phrase)
+                n_words += len(doc)
+    seconds = timer() - start
+    wps = n_words / seconds
+    print('components=', components, 'disabled=', disabled, 'use_pipe=', use_pipe, 'wps=', wps,
+          'words=', n_words, 'seconds=', seconds)
+
+if __name__ == '__main__':
+    plac.call(main)

--- a/tests/misc/py_script/test.sh
+++ b/tests/misc/py_script/test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+source activate spacy_condaenv
+python benchmark_small_docs.py 
+python benchmark_small_docs.py -p
+python benchmark_small_docs.py tagger   
+python benchmark_small_docs.py tagger -p 
+python benchmark_small_docs.py tagger,ner
+python benchmark_small_docs.py tagger,ner -p
+

--- a/tests/misc/py_script/test_v1.10.sh
+++ b/tests/misc/py_script/test_v1.10.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+source activate spacy_condaenv_v1.10.0
+python benchmark_small_docs.py -v
+python benchmark_small_docs.py -p -v
+python benchmark_small_docs.py tagger -v
+python benchmark_small_docs.py tagger -p -v
+python benchmark_small_docs.py tagger,ner -v
+python benchmark_small_docs.py tagger,ner -p -v
+

--- a/tests/misc/py_script/test_v2.sh
+++ b/tests/misc/py_script/test_v2.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source activate spacy_condaenv
+source activate spacy_condaenv_latest
 python benchmark_small_docs.py 
 python benchmark_small_docs.py -p
 python benchmark_small_docs.py tagger   

--- a/tests/testthat/test-5-spacy-install.R
+++ b/tests/testthat/test-5-spacy-install.R
@@ -21,14 +21,23 @@ test_that("spacy_install works", {
                    "Installation complete")
 })
 
-test_that("spacy_install spacy version 1 works", {
+test_that("spacy_install specific version of spacy works", {
     skip_on_cran()
     # skip_on_appveyor()
     skip_on_os("solaris")
     skip_if_no_python_or_no_spacy()
     
-    expect_message(spacy_install(envname = "test_v1", version = "latest_v1", 
+    expect_message(spacy_install(envname = "test_specific_version", version = "1.10.1", 
                                  prompt = FALSE), 
                    "Installation complete")
 })
 
+test_that("spacy_install_virtualenv works", {
+    skip_on_cran()
+    # skip_on_appveyor()
+    skip_on_os("solaris")
+    skip_if_no_python_or_no_spacy()
+    
+    expect_message(spacy_install_virtualenv(prompt = FALSE), 
+                   "Installation complete")
+})

--- a/tests/testthat/test-5-spacy-install.R
+++ b/tests/testthat/test-5-spacy-install.R
@@ -9,3 +9,33 @@ test_that("lanugage model download works", {
     
     expect_message(spacy_download_langmodel("de"), "successfully")
 })
+
+
+test_that("spacy_install works", {
+    skip_on_cran()
+    # skip_on_appveyor()
+    skip_on_os("solaris")
+    skip_if_no_python_or_no_spacy()
+    
+    expect_message(spacy_install(envname = "test_latest"), "Installation complete")
+})
+
+test_that("spacy_install spacy version 1 works", {
+    skip_on_cran()
+    # skip_on_appveyor()
+    skip_on_os("solaris")
+    skip_if_no_python_or_no_spacy()
+    
+    expect_message(spacy_install(envname = "test_v1", version = "latest_v1"), 
+                   "Installation complete")
+})
+
+test_that("spacy_uninstall works", {
+    skip_on_cran()
+    # skip_on_appveyor()
+    skip_on_os("solaris")
+    skip_if_no_python_or_no_spacy()
+    
+    expect_message(spacy_uninstall(envname = "test_latest"), 
+                   "Uninstallation complete")
+})

--- a/tests/testthat/test-5-spacy-install.R
+++ b/tests/testthat/test-5-spacy-install.R
@@ -32,15 +32,16 @@ test_that("spacy_install specific version of spacy works", {
                    "Installation complete")
 })
 
-test_that("spacy_install_virtualenv works", {
-    skip_on_cran()
-    # skip_on_appveyor()
-    skip_on_os("solaris")
-    skip_on_os("mac") # this test is travis only
-    skip_if_no_python_or_no_spacy()
-
-    expect_message(spacy_install_virtualenv(prompt = FALSE, 
-                                            python = paste0(path.expand("~"), 
-                                                            "/miniconda/bin/python")),
-                   "Installation complete")
-})
+# # Comment out for the time being
+# test_that("spacy_install_virtualenv works", {
+#     skip_on_cran()
+#     # skip_on_appveyor()
+#     skip_on_os("solaris")
+#     skip_on_os("mac") # this test is travis only
+#     skip_if_no_python_or_no_spacy()
+# 
+#     expect_message(spacy_install_virtualenv(prompt = FALSE, 
+#                                             python = paste0(path.expand("~"), 
+#                                                             "/miniconda/bin/python")),
+#                    "Installation complete")
+# })

--- a/tests/testthat/test-5-spacy-install.R
+++ b/tests/testthat/test-5-spacy-install.R
@@ -17,7 +17,8 @@ test_that("spacy_install works", {
     skip_on_os("solaris")
     skip_if_no_python_or_no_spacy()
     
-    expect_message(spacy_install(envname = "test_latest"), "Installation complete")
+    expect_message(spacy_install(envname = "test_latest", prompt = FALSE), 
+                   "Installation complete")
 })
 
 test_that("spacy_install spacy version 1 works", {
@@ -26,16 +27,8 @@ test_that("spacy_install spacy version 1 works", {
     skip_on_os("solaris")
     skip_if_no_python_or_no_spacy()
     
-    expect_message(spacy_install(envname = "test_v1", version = "latest_v1"), 
+    expect_message(spacy_install(envname = "test_v1", version = "latest_v1", 
+                                 prompt = FALSE), 
                    "Installation complete")
 })
 
-test_that("spacy_uninstall works", {
-    skip_on_cran()
-    # skip_on_appveyor()
-    skip_on_os("solaris")
-    skip_if_no_python_or_no_spacy()
-    
-    expect_message(spacy_uninstall(envname = "test_latest"), 
-                   "Uninstallation complete")
-})

--- a/tests/testthat/test-5-spacy-install.R
+++ b/tests/testthat/test-5-spacy-install.R
@@ -36,8 +36,11 @@ test_that("spacy_install_virtualenv works", {
     skip_on_cran()
     # skip_on_appveyor()
     skip_on_os("solaris")
+    skip_on_os("mac") # this test is travis only
     skip_if_no_python_or_no_spacy()
-    
-    expect_message(spacy_install_virtualenv(prompt = FALSE), 
+
+    expect_message(spacy_install_virtualenv(prompt = FALSE, 
+                                            python = paste0(path.expand("~"), 
+                                                            "/miniconda/bin/python")),
                    "Installation complete")
 })

--- a/tests/testthat/test-5-spacy-install.R
+++ b/tests/testthat/test-5-spacy-install.R
@@ -1,0 +1,11 @@
+context("spacy install")
+source("utils.R")
+
+test_that("lanugage model download works", {
+    skip_on_cran()
+    # skip_on_appveyor()
+    skip_on_os("solaris")
+    skip_if_no_python_or_no_spacy()
+    
+    expect_message(spacy_download_langmodel("de"), "successfully")
+})

--- a/tests/testthat/utils.R
+++ b/tests/testthat/utils.R
@@ -1,12 +1,12 @@
 skip_if_no_python_or_no_spacy <- function() {
-    if(Sys.info()['sysname'] == "Windows"){
+    if (Sys.info()['sysname'] == "Windows"){
         source_bash_profile <- FALSE
     } else {
         source_bash_profile <- TRUE
     }
-    if(find_spacy_env()) return(NULL)
+    if (find_spacy_env()) return(NULL)
     spacy_path <- find_spacy(ask = FALSE)
-    if(is.null(spacy_path)) {
+    if (is.null(spacy_path)) {
         skip("Skip the test as spaCy is not found")
     } else if (is.na(spacy_path)) {
         skip("Skip the test as python is not found")


### PR DESCRIPTION
This PR resolves following issues:

- #104 
- #103 

In addition, there are a few improvements

- Implemented `version='latest_v1'` option for `spacy_install()`. This option will install latest version 1 of spacy in a conda_environment. I updated a documentation to describe what it does and why needed.
- Added a few tests to increase the codecov coverage. (I wanted to have tests on `_virtualenv` functions but it seem a bit tricky to do that on travis and decided to pass on this time).