### PR TITLE
Fix build errors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Imports:
 Suggests:
     rmarkdown,
     testthat,
-    knitr.
+    knitr,
     quanteda
 URL: http://github.com/quanteda/spacyr
 Encoding: UTF-8

--- a/inst/python/initialize_spacyPython.py
+++ b/inst/python/initialize_spacyPython.py
@@ -1,8 +1,14 @@
 # from __future__ import unicode_literals 
 
 ## following lines are necessary for showing the version of spacy
-import pip
-installed_packages = pip.get_installed_distributions()
+## Dealing with pip 10.* api chagnes
+## The solution is from:
+## https://github.com/naiquevin/pipdeptree/blob/master/pipdeptree.py
+try:
+    from pip._internal import get_installed_distributions
+except ImportError:
+    from pip import get_installed_distributions
+installed_packages = get_installed_distributions()
 versions = {package.key: package.version for package in installed_packages}
 
 if 'spacy_entity' in locals() and spacy_entity == False and int(versions['spacy'][:1]) >= 2:


### PR DESCRIPTION
This PR fixes the travis build issues. The travis error has been coming from the API change of pip version 10 as pointed out in #110. 

https://github.com/pypa/pip/issues/5154#issuecomment-378197307

I can't believe that some core packages like pip are allowed to make such drastic change...