### PR TITLE
Remove dependency on internal pip API

### DIFF
--- a/R/spacy_initialize.R
+++ b/R/spacy_initialize.R
@@ -95,7 +95,7 @@ spacy_initialize <- function(model = "en",
     spacyr_pyexec(pyfile = system.file("python", "initialize_spacyPython.py",
                                        package = "spacyr"))
 
-    spacy_version <- spacyr_pyget("versions")$spacy
+    spacy_version <- spacyr_pyget("spacy_version")
     if(entity == FALSE && as.integer(substr(spacy_version, 1, 1)) < 2){
         message("entity == FALSE is only available for spaCy version 2.0.0 or higher")
         options("spacy_entity" = TRUE)

--- a/inst/python/initialize_spacyPython.py
+++ b/inst/python/initialize_spacyPython.py
@@ -5,9 +5,12 @@
 ## The solution is from:
 ## https://github.com/naiquevin/pipdeptree/blob/master/pipdeptree.py
 try:
-    from pip._internal import get_installed_distributions
+    from pip._internal.utils.misc import get_installed_distributions
 except ImportError:
-    from pip import get_installed_distributions
+    try:
+        from pip._internal import get_installed_distributions
+    except ImportError:
+        from pip import get_installed_distributions
 installed_packages = get_installed_distributions()
 versions = {package.key: package.version for package in installed_packages}
 

--- a/inst/python/initialize_spacyPython.py
+++ b/inst/python/initialize_spacyPython.py
@@ -1,20 +1,14 @@
 # from __future__ import unicode_literals 
 
-## following lines are necessary for showing the version of spacy
-## Dealing with pip 10.* api chagnes
-## The solution is from:
-## https://github.com/naiquevin/pipdeptree/blob/master/pipdeptree.py
+## Parser for version strings
 try:
-    from pip._internal.utils.misc import get_installed_distributions
+    from packaging.version import parse as VersionParser
 except ImportError:
-    try:
-        from pip._internal import get_installed_distributions
-    except ImportError:
-        from pip import get_installed_distributions
-installed_packages = get_installed_distributions()
-versions = {package.key: package.version for package in installed_packages}
+    from distutils.version import LooseVersion as VersionParser
 
-if 'spacy_entity' in locals() and spacy_entity == False and int(versions['spacy'][:1]) >= 2:
+spacy_version = spacy.about.__version__
+
+if 'spacy_entity' in locals() and spacy_entity == False and VersionParser(spacy_version) >= VersionParser("2"):
     nlp = spacy.load(model, disable=['ner'])
 else:
     nlp = spacy.load(model)


### PR DESCRIPTION
See #132 for context.

I have not extensively tested this for older versions of pip. But it works for 18.1.