### PR TITLE
Fix Issue 153

### DIFF
--- a/R/parse-extractor-functions.R
+++ b/R/parse-extractor-functions.R
@@ -141,14 +141,14 @@ get_noun_phrases <- function(spacy_out) {
     data_out <-
         data.table::rbindlist(lapply(doc_id, function(x) {
             df <- as.data.frame(noun_phrases[[x]], stringsAsFactors = FALSE)
-            if(nrow(df) == 0) return(NULL)
+            if (nrow(df) == 0) return(NULL)
             df$doc_id <- x
             return(df)
         }))
-    if(nrow(data_out) == 0) {
+    if (nrow(data_out) == 0) {
         return(NULL)
     }
-    
+
     data_out[, start_id := start_id + 1][, root_id := root_id + 1]
     data.table::setDF(data_out)
     data_out <- data_out[, c(6, 1:5)]

--- a/R/parse-extractor-functions.R
+++ b/R/parse-extractor-functions.R
@@ -141,9 +141,14 @@ get_noun_phrases <- function(spacy_out) {
     data_out <-
         data.table::rbindlist(lapply(doc_id, function(x) {
             df <- as.data.frame(noun_phrases[[x]], stringsAsFactors = FALSE)
+            if(nrow(df) == 0) return(NULL)
             df$doc_id <- x
             return(df)
         }))
+    if(nrow(data_out) == 0) {
+        return(NULL)
+    }
+    
     data_out[, start_id := start_id + 1][, root_id := root_id + 1]
     data.table::setDF(data_out)
     data_out <- data_out[, c(6, 1:5)]

--- a/R/spacy_extract_entity.R
+++ b/R/spacy_extract_entity.R
@@ -110,11 +110,11 @@ spacy_extract_entity.character <- function(x,
         data_out <-
             data.table::rbindlist(lapply(doc_id, function(x) {
                 df <- as.data.frame(entities[[x]], stringsAsFactors = FALSE)
-                if(nrow(df) == 0) return(NULL)
+                if (nrow(df) == 0) return(NULL)
                 df$doc_id <- x
                 return(df)
             }))
-        if(nrow(data_out) == 0) {
+        if (nrow(data_out) == 0) {
             message("No entity found in documents")
             return(NULL)
         }

--- a/R/spacy_extract_entity.R
+++ b/R/spacy_extract_entity.R
@@ -110,9 +110,14 @@ spacy_extract_entity.character <- function(x,
         data_out <-
             data.table::rbindlist(lapply(doc_id, function(x) {
                 df <- as.data.frame(entities[[x]], stringsAsFactors = FALSE)
+                if(nrow(df) == 0) return(NULL)
                 df$doc_id <- x
                 return(df)
             }))
+        if(nrow(data_out) == 0) {
+            message("No entity found in documents")
+            return(NULL)
+        }
         data_out[, start_id := start_id + 1]
         extended_list <- c("DATE", "TIME", "PERCENT", "MONEY", "QUANTITY", "ORDINAL",
                            "CARDINAL")

--- a/R/spacy_extract_nounphrases.R
+++ b/R/spacy_extract_nounphrases.R
@@ -104,15 +104,15 @@ spacy_extract_nounphrases.character <- function(x,
         data_out <-
             data.table::rbindlist(lapply(doc_id, function(x) {
                 df <- as.data.frame(noun_phrases[[x]], stringsAsFactors = FALSE)
-                if(nrow(df) == 0) return(NULL)
+                if (nrow(df) == 0) return(NULL)
                 df$doc_id <- x
                 return(df)
             }))
-        if(nrow(data_out) == 0) {
+        if (nrow(data_out) == 0) {
             message("No noun phrase found in documents")
             return(NULL)
         }
-        
+
         data_out[, start_id := start_id + 1][, root_id := root_id + 1]
         data.table::setDF(data_out)
         data_out <- data_out[, c(6, 1:5)]

--- a/R/spacy_extract_nounphrases.R
+++ b/R/spacy_extract_nounphrases.R
@@ -104,9 +104,15 @@ spacy_extract_nounphrases.character <- function(x,
         data_out <-
             data.table::rbindlist(lapply(doc_id, function(x) {
                 df <- as.data.frame(noun_phrases[[x]], stringsAsFactors = FALSE)
+                if(nrow(df) == 0) return(NULL)
                 df$doc_id <- x
                 return(df)
             }))
+        if(nrow(data_out) == 0) {
+            message("No noun phrase found in documents")
+            return(NULL)
+        }
+        
         data_out[, start_id := start_id + 1][, root_id := root_id + 1]
         data.table::setDF(data_out)
         data_out <- data_out[, c(6, 1:5)]

--- a/R/spacy_parse.R
+++ b/R/spacy_parse.R
@@ -140,23 +140,27 @@ spacy_parse.character <- function(x,
     if (nounphrase) {
         doc_id <- start_id <- nounphrase <- w_id <- root_id <- whitespace <- NULL
 
-        dt_nounphrases <- data.table::setDT(get_noun_phrases(spacy_out))
-        dt_nounphrases <- dt_nounphrases[rep(1:nrow(dt_nounphrases), times = length)]
-        dt_nounphrases[, w_id := seq(start_id[1], length.out = length[1]), by = .(doc_id, start_id)]
-        dt_nounphrases <- data.table::setorder(dt_nounphrases, w_id, -length)
-        dt_nounphrases <- unique(dt_nounphrases, by = c("doc_id", "w_id"))
-        dt_nounphrases[, nounphrase := ifelse(w_id == start_id, "beg",
-                                      ifelse(w_id == max(w_id), "end", "mid")), by = .(doc_id, start_id)]
-        dt_nounphrases[, nounphrase := ifelse(w_id == root_id, paste0(nounphrase, "_root"), nounphrase)]
-        dt[, w_id := seq_len(.N), by = doc_id]
-        dt <- merge(dt, dt_nounphrases, by  = c("doc_id", "w_id"), all.x = TRUE)
-        # dt[ !is.na(start_id), start_token_id := token_id[w_id == start_id][1],
-        #     by = .(doc_id, root_id)]
-        # dt[ !is.na(start_id), root_token_id := token_id[w_id == root_id][1],
-        #     by = .(doc_id, root_id)]
-        dt[, c("w_id", "start_id", "root_id", "text", "root_text", "length") := NULL]
-        dt[, whitespace := ifelse(nchar(get_attrs(spacy_out, "whitespace_")), TRUE, FALSE)]
-        dt[, nounphrase := ifelse(is.na(nounphrase), "", nounphrase)]
+        dt_nounphrases <- data.table::data.table(get_noun_phrases(spacy_out))
+        if(nrow(dt_nounphrases) > 0) {
+            dt_nounphrases <- dt_nounphrases[rep(1:nrow(dt_nounphrases), times = length)]
+            dt_nounphrases[, w_id := seq(start_id[1], length.out = length[1]), by = .(doc_id, start_id)]
+            dt_nounphrases <- data.table::setorder(dt_nounphrases, w_id, -length)
+            dt_nounphrases <- unique(dt_nounphrases, by = c("doc_id", "w_id"))
+            dt_nounphrases[, nounphrase := ifelse(w_id == start_id, "beg",
+                                          ifelse(w_id == max(w_id), "end", "mid")), by = .(doc_id, start_id)]
+            dt_nounphrases[, nounphrase := ifelse(w_id == root_id, paste0(nounphrase, "_root"), nounphrase)]
+            dt[, w_id := seq_len(.N), by = doc_id]
+            dt <- merge(dt, dt_nounphrases, by  = c("doc_id", "w_id"), all.x = TRUE)
+            # dt[ !is.na(start_id), start_token_id := token_id[w_id == start_id][1],
+            #     by = .(doc_id, root_id)]
+            # dt[ !is.na(start_id), root_token_id := token_id[w_id == root_id][1],
+            #     by = .(doc_id, root_id)]
+            dt[, c("w_id", "start_id", "root_id", "text", "root_text", "length") := NULL]
+            dt[, whitespace := ifelse(nchar(get_attrs(spacy_out, "whitespace_")), TRUE, FALSE)]
+            dt[, nounphrase := ifelse(is.na(nounphrase), "", nounphrase)]
+        } else {
+            message("No noun phrase found in documents.")
+        }
     }
 
     if (!is.null(additional_attributes)) {

--- a/R/spacy_parse.R
+++ b/R/spacy_parse.R
@@ -141,7 +141,7 @@ spacy_parse.character <- function(x,
         doc_id <- start_id <- nounphrase <- w_id <- root_id <- whitespace <- NULL
 
         dt_nounphrases <- data.table::data.table(get_noun_phrases(spacy_out))
-        if(nrow(dt_nounphrases) > 0) {
+        if (nrow(dt_nounphrases) > 0) {
             dt_nounphrases <- dt_nounphrases[rep(1:nrow(dt_nounphrases), times = length)]
             dt_nounphrases[, w_id := seq(start_id[1], length.out = length[1]), by = .(doc_id, start_id)]
             dt_nounphrases <- data.table::setorder(dt_nounphrases, w_id, -length)

--- a/tests/testthat/test-4-entity-functions.R
+++ b/tests/testthat/test-4-entity-functions.R
@@ -28,9 +28,9 @@ test_that("spacy_extract_entity data.frame works properly when there is no noun-
     # skip_on_appveyor()
     skip_on_os("solaris")
     skip_if_no_python_or_no_spacy()
-    
+
     expect_message(spacy_initialize(), "successfully|already")
-    
+
     txt1 <- c(doc1 = "He told me all this very much later, but I've put it down here with the idea of exploding those wild rumors about his antecedents, which weren t even faintly true.")
     expect_message(
         spacy_extract_entity(txt1, output = "data.frame"),

--- a/tests/testthat/test-4-entity-functions.R
+++ b/tests/testthat/test-4-entity-functions.R
@@ -23,6 +23,24 @@ test_that("spacy_extract_entity data.frame works", {
     expect_silent(spacy_finalize())
 })
 
+test_that("spacy_extract_entity data.frame works properly when there is no noun-phrase", {
+    skip_on_cran()
+    # skip_on_appveyor()
+    skip_on_os("solaris")
+    skip_if_no_python_or_no_spacy()
+    
+    expect_message(spacy_initialize(), "successfully|already")
+    
+    txt1 <- c(doc1 = "He told me all this very much later, but I've put it down here with the idea of exploding those wild rumors about his antecedents, which weren t even faintly true.")
+    expect_message(
+        spacy_extract_entity(txt1, output = "data.frame"),
+        "No entity")
+    expect_equivalent(
+        spacy_extract_entity(txt1, output = "data.frame"),
+        NULL)
+})
+
+
 test_that("spacy_extract_entity list works", {
     skip_on_cran()
     # skip_on_appveyor()

--- a/tests/testthat/test-5-nounphrase-functions.R
+++ b/tests/testthat/test-5-nounphrase-functions.R
@@ -41,9 +41,9 @@ test_that("spacy_extract_nounphrases data.frame works properly when there is no 
     # skip_on_appveyor()
     skip_on_os("solaris")
     skip_if_no_python_or_no_spacy()
-    
+
     expect_message(spacy_initialize(), "successfully|already")
-    
+
     txt1 <- c(doc1 = "Hello")
     expect_message(
         spacy_extract_nounphrases(txt1, output = "data.frame"),
@@ -207,16 +207,15 @@ test_that("spacy_parse nounphrase = TRUE return message when there is no nounphr
     # skip_on_appveyor()
     skip_on_os("solaris")
     skip_if_no_python_or_no_spacy()
-    
+
     expect_message(spacy_initialize(), "successfully|already")
-    
+
     txt1 <- c(doc1 = "hello",
               doc2 = "hello")
-    parsed <- 
-    
+
     expect_message(
         spacy_parse(txt1, nounphrase = TRUE),
-        "No noun phrase" 
+        "No noun phrase"
     )
     expect_false(
         "nounphrase" %in% names(spacy_parse(txt1, nounphrase = TRUE))

--- a/tests/testthat/test-5-nounphrase-functions.R
+++ b/tests/testthat/test-5-nounphrase-functions.R
@@ -36,6 +36,23 @@ test_that("spacy_extract_nounphrases data.frame works", {
 })
 
 
+test_that("spacy_extract_nounphrases data.frame works properly when there is no noun-phrase", {
+    skip_on_cran()
+    # skip_on_appveyor()
+    skip_on_os("solaris")
+    skip_if_no_python_or_no_spacy()
+    
+    expect_message(spacy_initialize(), "successfully|already")
+    
+    txt1 <- c(doc1 = "Hello")
+    expect_message(
+        spacy_extract_nounphrases(txt1, output = "data.frame"),
+        "No noun phrase")
+    expect_equivalent(
+        spacy_extract_nounphrases(txt1, output = "data.frame"),
+        NULL)
+})
+
 test_that("spacy_extract_nounphrases works with a TIF formatted data.frame", {
     skip_on_cran()
     # skip_on_appveyor()
@@ -182,6 +199,31 @@ test_that("spacy_parse nounphrase = TRUE works", {
 
 
     expect_silent(spacy_finalize())
+})
+
+
+test_that("spacy_parse nounphrase = TRUE return message when there is no nounphrase", {
+    skip_on_cran()
+    # skip_on_appveyor()
+    skip_on_os("solaris")
+    skip_if_no_python_or_no_spacy()
+    
+    expect_message(spacy_initialize(), "successfully|already")
+    
+    txt1 <- c(doc1 = "hello",
+              doc2 = "hello")
+    parsed <- 
+    
+    expect_message(
+        spacy_parse(txt1, nounphrase = TRUE),
+        "No noun phrase" 
+    )
+    expect_false(
+        "nounphrase" %in% names(spacy_parse(txt1, nounphrase = TRUE))
+    )
+    expect_false(
+        "whitespace" %in% names(spacy_parse(txt1, nounphrase = TRUE))
+    )
 })
 
 test_that("nounphrase_extract() on parsed object works", {


### PR DESCRIPTION
`spacry_extract_*` functions returned an error when all documents do not have a named-entity/noun-phrase.

Closes #153 
