### PR TITLE
Issue 157

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: spacyr
 Type: Package
 Title: Wrapper to the 'spaCy' 'NLP' Library
-Version: 1.0.1
+Version: 1.0.2
 Authors@R: c(
     person("Kenneth", "Benoit", email = "kbenoit@lse.ac.uk", role = c("cre", "aut", "cph"), comment = c(ORCID = "0000-0002-0797-564X")), 
     person("Akitaka", "Matsuo", email = "a.matsuo@lse.ac.uk", role = "aut", comment = c(ORCID = "0000-0002-3323-6330")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # Since v1.0
 
 * Fixed a bug in `spacy_parse(x, nounphrase = TRUE)` that occurred when no noun phrases were found in the text.  (#153)
+* Fixed a bug in `spacy_initialize()` (#157). `spacy_initialize()` ignored Python options supplied by users when a conda environment created through `spacy_install()` exists.
 
 # v1.0
 

--- a/R/spacy_initialize.R
+++ b/R/spacy_initialize.R
@@ -239,18 +239,7 @@ set_spacy_python_option <- function(python_executable = NULL,
         settings <- check_spacy_python_options()
         message("spacy python option is already set, spacyr will use:\n\t",
                 sub("spacy_", "", settings$key), ' = "', settings$val, '"')
-    } else if (check_env &&
-              !(is.null(tryCatch(reticulate::conda_binary("auto"), error = function(e) NULL))) &&
-              "spacy_condaenv" %in% reticulate::conda_list(conda = "auto")$name) {
-        message("Found 'spacy_condaenv'. spacyr will use this environment")
-        clear_spacy_options()
-        options(spacy_condaenv = "spacy_condaenv")
-    }
-    else if (check_env && file.exists(file.path("~/.virtualenvs", "spacy_virtualenv", "bin", "activate"))) {
-        message("Found 'spacy_virtualenv'. spacyr will use this environment")
-        clear_spacy_options()
-        options(spacy_virtualenv = "~/.virtualenvs/spacy_virtualenv")
-    }
+    }     
     # a user can specify only one
     else if (sum(!is.null(c(python_executable, virtualenv, condaenv))) > 1) {
         stop(paste("Too many python environments are specified, please select only one",
@@ -273,7 +262,21 @@ set_spacy_python_option <- function(python_executable = NULL,
             clear_spacy_options()
             options(spacy_condaenv = condaenv)
         }
-    } else {
+        
+    } 
+    else if (check_env &&
+              !(is.null(tryCatch(reticulate::conda_binary("auto"), error = function(e) NULL))) &&
+              "spacy_condaenv" %in% reticulate::conda_list(conda = "auto")$name) {
+        message("Found 'spacy_condaenv'. spacyr will use this environment")
+        clear_spacy_options()
+        options(spacy_condaenv = "spacy_condaenv")
+    }
+    else if (check_env && file.exists(file.path("~/.virtualenvs", "spacy_virtualenv", "bin", "activate"))) {
+        message("Found 'spacy_virtualenv'. spacyr will use this environment")
+        clear_spacy_options()
+        options(spacy_virtualenv = "~/.virtualenvs/spacy_virtualenv")
+    }
+    else {
         message("Finding a python executable with spaCy installed...")
         spacy_python <- find_spacy(model, ask = ask)
         if (is.null(spacy_python)) {

--- a/R/spacy_initialize.R
+++ b/R/spacy_initialize.R
@@ -239,7 +239,7 @@ set_spacy_python_option <- function(python_executable = NULL,
         settings <- check_spacy_python_options()
         message("spacy python option is already set, spacyr will use:\n\t",
                 sub("spacy_", "", settings$key), ' = "', settings$val, '"')
-    }     
+    }
     # a user can specify only one
     else if (sum(!is.null(c(python_executable, virtualenv, condaenv))) > 1) {
         stop(paste("Too many python environments are specified, please select only one",
@@ -262,8 +262,7 @@ set_spacy_python_option <- function(python_executable = NULL,
             clear_spacy_options()
             options(spacy_condaenv = condaenv)
         }
-        
-    } 
+    }
     else if (check_env &&
               !(is.null(tryCatch(reticulate::conda_binary("auto"), error = function(e) NULL))) &&
               "spacy_condaenv" %in% reticulate::conda_list(conda = "auto")$name) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ image: Visual Studio 2015
 environment:
   NOT_CRAN: true
   USE_RTOOLS: true
-  R_VERSION: 3.4.4
+  R_VERSION: 3.5.2
   PATH: "%PATH%;C:\\MinGW\\bin;C:\\MinGW\\msys\\1.0;C:\\MinGW\\msys\\1.0\\bin"
   matrix:
     - PYTHON: "C:\\Python36"


### PR DESCRIPTION
To change the order of checking python options. 

Previously, **spacyr** ignores python options provided by users when there is a conda environment named `spacy_condaenv` because the existence of this environment was the first thing **spacyr** looks for. We resolve this problem by changing the orders of checking the python environment.

Closes #157 