### PR TITLE
Option for "conda install"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_script:
   # Useful for debugging any issues with conda
   - conda info -a
   - R CMD INSTALL .
-  - R -e 'spacyr::spacy_install(prompt=FALSE)'
+  - R -e 'spacyr::spacy_install(prompt=FALSE, pip=TRUE)'
   - R -e 'spacyr::spacy_download_langmodel(model="de")'
 
 env:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: spacyr
 Type: Package
 Title: Wrapper to the 'spaCy' 'NLP' Library
-Version: 1.1
+Version: 1.1.1
 Authors@R: c(
     person("Kenneth", "Benoit", email = "kbenoit@lse.ac.uk", role = c("cre", "aut", "cph"), comment = c(ORCID = "0000-0002-0797-564X")), 
     person("Akitaka", "Matsuo", email = "a.matsuo@lse.ac.uk", role = "aut", comment = c(ORCID = "0000-0002-3323-6330")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 
 # spacyr v1.1.1
 
-* Add an option for using conda package mananger instead of `pip` in `spacy_install()` and `spacy_upgrade()`. 
+* Added an option for using conda package manager instead of `pip` in `spacy_install()` and `spacy_upgrade()`. 
 
 # spacyr v1.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+
+# spacyr v1.1.1
+
+* Add an option for using conda package mananger instead of `pip` in `spacy_install()` and `spacy_upgrade()`. 
+
 # spacyr v1.1
 
 * Fixed a bug in `spacy_parse(x, nounphrase = TRUE)` that occurred when no noun phrases were found in the text.  (#153)

--- a/R/spacy_install.R
+++ b/R/spacy_install.R
@@ -618,7 +618,7 @@ install_miniconda <- function() {
 }
 
 pip_get_version <- function(cmd, major_version) {
-    regex <- "^(\\w+)\\s?(.*)$"
+    regex <- "^(\\S+)\\s?(.*)$"
     cmd1 <- sub(regex, "\\1", cmd)
     cmd2 <- sub(regex, "\\2", cmd)
     oldw <- getOption("warn")
@@ -638,7 +638,7 @@ conda_get_version <- function(major_version = NA, conda, envname) {
                    shQuote(path.expand(condaenv_bin("activate"))),
                    envname,
                    ifelse(is_windows(), "", ifelse(is_osx(), "", "\"")))
-    regex <- "^(\\w+)\\s?(.*)$"
+    regex <- "^(\\S+)\\s?(.*)$"
     cmd1 <- sub(regex, "\\1", cmd)
     cmd2 <- sub(regex, "\\2", cmd)
     oldw <- getOption("warn")

--- a/R/spacy_install.R
+++ b/R/spacy_install.R
@@ -560,7 +560,7 @@ spacy_upgrade  <- function(conda = "auto",
                                                  version = "latest_v1",
                                                  lang_models = lang_models,
                                                  python_version = "3.6",
-                                                 prompt = FALSE, 
+                                                 prompt = FALSE,
                                                  pip = pip)
             }
         }
@@ -581,7 +581,7 @@ spacy_upgrade  <- function(conda = "auto",
                                              version = "latest",
                                              lang_models = lang_models,
                                              python_version = "3.6",
-                                             prompt = FALSE, 
+                                             prompt = FALSE,
                                              pip = pip)
             message("\nSuccessfully upgraded\n",
                     sprintf("Condaenv: %s; Langage model(s): ", envname), lang_models, "\n")
@@ -633,22 +633,20 @@ pip_get_version <- function(cmd, major_version) {
 
 conda_get_version <- function(major_version = NA, conda, envname) {
     condaenv_bin <- function(bin) path.expand(file.path(dirname(conda), bin))
-    cmd <- sprintf("%s%s %s && conda search spacy -c conda-forge",
+    cmd <- sprintf("%s%s %s && conda search spacy -c conda-forge%s",
                    ifelse(is_windows(), "", ifelse(is_osx(), "source ", "/bin/bash -c \"source ")),
                    shQuote(path.expand(condaenv_bin("activate"))),
-                   envname)
+                   envname,
+                   ifelse(is_windows(), "", ifelse(is_osx(), "", "\"")))
     regex <- "^(\\w+)\\s?(.*)$"
     cmd1 <- sub(regex, "\\1", cmd)
     cmd2 <- sub(regex, "\\2", cmd)
     oldw <- getOption("warn")
     result <- system2(cmd1, cmd2, stdout = TRUE, stderr = TRUE)
     result <- sub("\\S+\\s+(\\S+)\\s.+", "\\1", result)
-    if(!is.na(major_version)) {
+    if (!is.na(major_version)) {
         result <- grep(paste0("^", major_version, "\\."), result, value = T)
     }
-    
     #version_check_regex <- sprintf(".+(%s.\\d+\\.\\d+).+", major_version)
     return(result[length(result)])
 }
-
-

--- a/R/spacy_install.R
+++ b/R/spacy_install.R
@@ -104,7 +104,7 @@ spacy_install <- function(conda = "auto",
             }
 
             # process the installation of spacy
-            process_spacy_installation_conda(conda, version, lang_models, 
+            process_spacy_installation_conda(conda, version, lang_models,
                                              python_version, prompt,
                                              envname = envname, pip = pip)
 
@@ -129,7 +129,7 @@ spacy_install <- function(conda = "auto",
         }
 
         # process the installation of spacy
-        process_spacy_installation_conda(conda, version, lang_models, 
+        process_spacy_installation_conda(conda, version, lang_models,
                                          python_version, prompt,
                                          envname = envname, pip = pip)
 
@@ -305,7 +305,6 @@ process_spacy_installation_conda <- function(conda, version, lang_models, python
                        ifelse(is_windows(), "", ifelse(is_osx(), "", "\"")))
         pip_get_version(cmd = cmd, major_version = major_version)
     }
-    
     # install base spaCy using pip
     if (version == "latest_v1") {
         version <- ifelse(pip, pip_get_version_conda(1),
@@ -538,7 +537,7 @@ spacy_upgrade  <- function(conda = "auto",
             message("\nSuccessfully upgraded\n",
                     sprintf("Condaenv: %s; Langage model(s): ", envname), lang_models, "\n")
         } else {
-            if(pip){
+            if (pip == TRUE) {
                 cmd <- sprintf("%s%s %s && pip install --upgrade %s %s%s",
                                ifelse(is_windows(), "", ifelse(is_osx(), "source ", "/bin/bash -c \"source ")),
                                shQuote(path.expand(condaenv_bin("activate"))),
@@ -546,17 +545,14 @@ spacy_upgrade  <- function(conda = "auto",
                                "--ignore-installed",
                                paste(shQuote("spacy==random"), collapse = " "),
                                ifelse(is_windows(), "", ifelse(is_osx(), "", "\"")))
-                
                 latest_spacy_v1 <- pip_get_version(cmd, major_version = 1)
             } else {
                 latest_spacy_v1 <- conda_get_version(major_version = 1, conda, envname)
             }
-            
             if (latest_spacy_v1 == installed_spacy){
                 message("your spaCy is the latest v1")
                 return(invisible(NULL))
             } else {
-
                 cat(sprintf("A new version of spaCy v1 (%s) will be installed (installed version: %s)\n",
                             latest_spacy_v1, installed_spacy))
                 process_spacy_installation_conda(conda = conda,

--- a/man/spacy_install.Rd
+++ b/man/spacy_install.Rd
@@ -6,7 +6,7 @@
 \title{Install spaCy in conda or virtualenv environment}
 \usage{
 spacy_install(conda = "auto", version = "latest", lang_models = "en",
-  python_version = "3.6", envname = "spacy_condaenv",
+  python_version = "3.6", envname = "spacy_condaenv", pip = FALSE,
   python_path = NULL, prompt = TRUE)
 
 spacy_install_virtualenv(version = "latest", lang_models = "en",
@@ -33,6 +33,9 @@ installation. 3.5 and 3.6 are available.}
 
 \item{envname}{character; name of the conda-environment to install spaCy. 
 Default is "spacy_condaenv".}
+
+\item{pip}{\code{TRUE} to use pip for installing spacy. If \code{FALSE}, conda 
+package manager with conda-forge channel will be used for installing spacy.}
 
 \item{python_path}{character; path to Python in virtualenv installation}
 

--- a/man/spacy_upgrade.Rd
+++ b/man/spacy_upgrade.Rd
@@ -2,10 +2,10 @@
 % Please edit documentation in R/spacy_install.R
 \name{spacy_upgrade}
 \alias{spacy_upgrade}
-\title{Install spaCy in conda environment}
+\title{Upgrade spaCy in conda environment}
 \usage{
 spacy_upgrade(conda = "auto", envname = "spacy_condaenv",
-  prompt = TRUE, lang_models = "en")
+  prompt = TRUE, pip = FALSE, lang_models = "en")
 }
 \arguments{
 \item{conda}{Path to conda executable. Default "auto" which automatically
@@ -15,9 +15,12 @@ find the path}
 
 \item{prompt}{logical; ask whether to proceed during the installation}
 
+\item{pip}{\code{TRUE} to use pip for installing spacy. If \code{FALSE}, conda 
+package manager with conda-forge channel will be used for installing spacy.}
+
 \item{lang_models}{Language models to be upgraded. Default NULL (No upgrade). 
 A vector of multiple model names can be used (e.g. \code{c("en", "de")})}
 }
 \description{
-Install spaCy in conda environment
+Upgrade spaCy in conda environment
 }

--- a/tests/testthat/test-7-spacy-install.R
+++ b/tests/testthat/test-7-spacy-install.R
@@ -33,7 +33,7 @@ test_that("spacy_install specific version of spacy works", {
     # expect_message(spacy_install(envname = "test_specific_version", version = "2.0.1",
     #                              prompt = FALSE),
     #                "Installation complete")
-    expect_message(spacy_install(envname = "test_specific_version_v1", version = "1.10.1",
+    expect_message(spacy_install(envname = "test_specific_version_v1", version = "1.9.0",
                                  prompt = FALSE),
                    "Installation complete")
 })
@@ -45,7 +45,7 @@ test_that("spacy_upgrade works", {
     skip_on_os("solaris")
     skip_if_no_python_or_no_spacy()
 
-    expect_message(spacy_upgrade(prompt = FALSE),
+    expect_message(spacy_upgrade(envname = "test_latest", prompt = FALSE),
                    "Your spaCy version is the latest available")
     # expect_message(spacy_upgrade(envname = "test_specific_version",
     #                              prompt = FALSE),

--- a/tests/testthat/test-7-spacy-install.R
+++ b/tests/testthat/test-7-spacy-install.R
@@ -21,6 +21,8 @@ test_that("spacy_install works", {
                    "Installation complete")
 })
 
+
+
 test_that("spacy_install specific version of spacy works", {
     skip_on_cran()
     skip_on_appveyor()
@@ -69,6 +71,33 @@ test_that("spacy_uninstall works", {
     expect_output(spacy_uninstall(envname = "test_specific_version_v1",
                                   prompt = FALSE),
                   "Uninstallation complete")
+    expect_output(spacy_uninstall(envname = "test_latest",
+                                  prompt = FALSE),
+                  "Uninstallation complete")
+    
+})
+
+test_that("spacy_install etc with pip still works", {
+    skip_on_cran()
+    skip_on_appveyor()
+    skip_on_os("solaris")
+    skip_if_no_python_or_no_spacy()
+    
+    expect_message(spacy_install(envname = "test_latest_pip", prompt = FALSE, pip = TRUE),
+                   "Installation complete")
+    expect_message(spacy_install(envname = "test_old_pip", version = "2.0.4",
+                                 prompt = FALSE, pip = TRUE),
+                   "Installation complete")
+    expect_message(spacy_upgrade(envname = "test_old_pip", pip = TRUE,
+                                 prompt = FALSE),
+                   "Successfully upgraded")
+    expect_output(spacy_uninstall(envname = "test_latest_pip",
+                                  prompt = FALSE),
+                  "Uninstallation complete")
+    expect_output(spacy_uninstall(envname = "test_old_pip",
+                                  prompt = FALSE),
+                  "Uninstallation complete")
+    
 })
 
 
@@ -83,4 +112,6 @@ test_that("spacy_install_virtualenv works", {
                                             python = paste0(path.expand("~"),
                                                             "/miniconda/bin/python")),
                    "Installation complete")
+    
 })
+

--- a/tests/testthat/test-7-spacy-install.R
+++ b/tests/testthat/test-7-spacy-install.R
@@ -78,6 +78,7 @@ test_that("spacy_uninstall works", {
 })
 
 test_that("spacy_install etc with pip still works", {
+    skip("takes too much time and triggers timeout...")
     skip_on_cran()
     skip_on_appveyor()
     skip_on_os("solaris")

--- a/tests/testthat/test-7-spacy-install.R
+++ b/tests/testthat/test-7-spacy-install.R
@@ -96,7 +96,6 @@ test_that("spacy_install etc with pip still works", {
     expect_output(spacy_uninstall(envname = "test_old_pip",
                                   prompt = FALSE),
                   "Uninstallation complete")
-    
 })
 
 test_that("spacy_install_virtualenv works", {

--- a/tests/testthat/test-7-spacy-install.R
+++ b/tests/testthat/test-7-spacy-install.R
@@ -74,7 +74,6 @@ test_that("spacy_uninstall works", {
     expect_output(spacy_uninstall(envname = "test_latest",
                                   prompt = FALSE),
                   "Uninstallation complete")
-    
 })
 
 test_that("spacy_install etc with pip still works", {
@@ -83,7 +82,6 @@ test_that("spacy_install etc with pip still works", {
     skip_on_appveyor()
     skip_on_os("solaris")
     skip_if_no_python_or_no_spacy()
-    
     expect_message(spacy_install(envname = "test_latest_pip", prompt = FALSE, pip = TRUE),
                    "Installation complete")
     expect_message(spacy_install(envname = "test_old_pip", version = "2.0.4",
@@ -101,7 +99,6 @@ test_that("spacy_install etc with pip still works", {
     
 })
 
-
 test_that("spacy_install_virtualenv works", {
     skip("not tested for the time being")
     skip_on_appveyor()
@@ -113,6 +110,4 @@ test_that("spacy_install_virtualenv works", {
                                             python = paste0(path.expand("~"),
                                                             "/miniconda/bin/python")),
                    "Installation complete")
-    
 })
-


### PR DESCRIPTION
This branch has a new option for installing spacy in conda environment. In the current master, spacy is installed through `pip install`. This is potentially problematic because `pip install` requires the compilation of source code and:

1. the compilation frequently fails in many user setups
2. the installation takes times

This branch introduces a new option for installing through `conda install` from conda-forge repository, which is updated almost immediately after `pip` update. The option is controlled by `pip` option of `spacy_install()`.

Also:
Version 1.1 => 1.1.1

Close #166