### PR TITLE
Coerce character

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,13 @@ before_script:
   # Useful for debugging any issues with conda
   - conda info -a
   - R CMD INSTALL .
-  - R -e 'spacyr::spacy_install(prompt=FALSE, lang_models = "en")'
+  - R -e 'spacyr::spacy_install(prompt=FALSE)'
+  # The following lines will be removed once issue-171 is merged
+  # - source ~/miniconda/etc/profile.d/conda.sh
+  # - conda activate spacy_condaenv
+  # - python -m spacy link en_core_web_sm en
+  # - conda deactivate
+  - R -e 'spacyr::spacy_download_langmodel(model="en")' # create a link 'en'
   - R -e 'spacyr::spacy_download_langmodel(model="de")'
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ before_script:
   # - conda activate spacy_condaenv
   # - python -m spacy link en_core_web_sm en
   # - conda deactivate
+  - conda install -n spacy_condaenv -c omgarcia gcc-6 # https://github.com/conda/conda/issues/8415
   - R -e 'spacyr::spacy_download_langmodel(model="en")' # create a link 'en'
   - R -e 'spacyr::spacy_download_langmodel(model="de")'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,11 @@ before_script:
   # Useful for debugging any issues with conda
   - conda info -a
   - R CMD INSTALL .
-  - R -e 'spacyr::spacy_install(prompt=FALSE, pip=TRUE)'
+  - R -e 'spacyr::spacy_install(prompt=FALSE)'
+  # The following lines will be removed once issue-171 is merged
+  - conda activate spacy_condaenv
+  - python -m spacy link en_core_web_sm en
+  - conda deactivate
   - R -e 'spacyr::spacy_download_langmodel(model="de")'
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,13 +40,13 @@ before_script:
   # Useful for debugging any issues with conda
   - conda info -a
   - R CMD INSTALL .
-  - R -e 'spacyr::spacy_install(prompt=FALSE)'
+  - R -e 'spacyr::spacy_install(prompt=FALSE, pip = TRUE)'
   # The following lines will be removed once issue-171 is merged
   # - source ~/miniconda/etc/profile.d/conda.sh
   # - conda activate spacy_condaenv
   # - python -m spacy link en_core_web_sm en
   # - conda deactivate
-  - conda install -n spacy_condaenv -c omgarcia gcc-6 # https://github.com/conda/conda/issues/8415
+  # - conda install -n spacy_condaenv -c omgarcia gcc-6 # https://github.com/conda/conda/issues/8415
   - R -e 'spacyr::spacy_download_langmodel(model="en")' # create a link 'en'
   - R -e 'spacyr::spacy_download_langmodel(model="de")'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_script:
   # Useful for debugging any issues with conda
   - conda info -a
   - R CMD INSTALL .
-  - R -e 'spacyr::spacy_install(prompt=FALSE, model = "en")'
+  - R -e 'spacyr::spacy_install(prompt=FALSE, lang_models = "en")'
   - R -e 'spacyr::spacy_download_langmodel(model="de")'
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,11 +40,7 @@ before_script:
   # Useful for debugging any issues with conda
   - conda info -a
   - R CMD INSTALL .
-  - R -e 'spacyr::spacy_install(prompt=FALSE)'
-  # The following lines will be removed once issue-171 is merged
-  - conda activate spacy_condaenv
-  - python -m spacy link en_core_web_sm en
-  - conda deactivate
+  - R -e 'spacyr::spacy_install(prompt=FALSE, model = "en")'
   - R -e 'spacyr::spacy_download_langmodel(model="de")'
 
 env:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,6 @@ Imports:
 Suggests:
     dplyr,
     knitr,
-    lintr,
     quanteda, 
     R.rsp,
     rmarkdown,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: spacyr
 Type: Package
 Title: Wrapper to the 'spaCy' 'NLP' Library
-Version: 1.2
+Version: 1.21
 Authors@R: c(
     person("Kenneth", "Benoit", email = "kbenoit@lse.ac.uk", role = c("cre", "aut", "cph"), comment = c(ORCID = "0000-0002-0797-564X")), 
     person("Akitaka", "Matsuo", email = "a.matsuo@lse.ac.uk", role = "aut", comment = c(ORCID = "0000-0002-3323-6330")),
@@ -31,6 +31,6 @@ Suggests:
 URL: https://spacyr.quanteda.io
 Encoding: UTF-8
 BugReports: https://github.com/quanteda/spacyr/issues
-RoxygenNote: 6.1.1
+RoxygenNote: 7.0.2
 Language: en-GB
 VignetteBuilder: R.rsp

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 
 # spacyr v1.2
 
-* Added an option for using conda package manager instead of `pip` in `spacy_install()` and `spacy_upgrade()`. 
+* Added an option for using conda package manager instead of `pip` in `spacy_install()` and `spacy_upgrade()`.
+* (1.21) All character inputs to `spacy_parse()` and `spacy_tokenize()` are now coerced to `character`, which allows them to work directly with **quanteda** v2 corpus objects (which are based on the `character` class but with special attributed), without special methods.
 
 # spacyr v1.1
 

--- a/R/spacy_install.R
+++ b/R/spacy_install.R
@@ -25,14 +25,13 @@
 #'   automatically install the latest version of spaCy v1.*, using \code{version
 #'   = "latest_v1"}.
 #'   
-#' @inheritParams reticulate::conda_list
 #' @param conda character; path to conda executable. Default "auto" which
 #'   automatically find the path
 #' @param pip \code{TRUE} to use pip for installing spacy. If \code{FALSE}, conda 
 #' package manager with conda-forge channel will be used for installing spacy.
 #' @param lang_models character; language models to be installed. Default
-#'   \code{en} (English model). A vector of multiple model names can be used
-#'   (e.g. \code{c("en", "de")}).  A list of available language models and their
+#'   \code{en_core_web_sm} (English model). A vector of multiple model names can be used
+#'   (e.g. \code{c("en_core_web_sm", "de_core_news_sm")}).  A list of available language models and their
 #'   names is available from the \href{https://spacy.io/usage/models}{spaCy
 #'   language models} page.
 #' @param version character; spaCy version to install. Specify \code{"latest"}
@@ -49,7 +48,7 @@
 #' @examples 
 #' \dontrun{
 #' # install spaCy in a miniconda environment (macOS and Linux)
-#' spacy_install(lang_models = c("en", "de"), prompt = FALSE)
+#' spacy_install(lang_models = c("en_core_web_sm", "de_core_news_sm"), prompt = FALSE)
 #' 
 #' # install spaCy to an existing conda environment
 #' spacy_install(conda = "~/anaconda/bin/")
@@ -58,7 +57,7 @@
 #' @export
 spacy_install <- function(conda = "auto",
                           version = "latest",
-                          lang_models = "en",
+                          lang_models = "en_core_web_sm",
                           python_version = "3.6",
                           envname = "spacy_condaenv",
                           pip = FALSE,
@@ -67,6 +66,15 @@ spacy_install <- function(conda = "auto",
     # verify os
     if (!is_windows() && !is_osx() && !is_linux()) {
         stop("This function is available only for Windows, Mac, and Linux")
+    }
+
+    # model name check
+    if (any(lang_models %in% c('en', 'de', 'es', 'pt', 'fr', 'it', 'nl', 'el', 'nb', 'lt') == TRUE)) {
+        model <-
+            lang_models[lang_models %in%
+                            c('en', 'de', 'es', 'pt', 'fr', 'it', 'nl', 'el', 'nb', 'lt') == TRUE][1]
+        stop('An abbreviation of the model name, "', model, '", is provided.\n',
+             '  Please use a full model name (e.g. "', model, '_core_', ifelse(model == 'en', 'web', 'news'),'_sm").\n')
     }
 
     # verify 64-bit
@@ -146,11 +154,11 @@ spacy_install <- function(conda = "auto",
 #' @examples
 #' \dontrun{
 #' # install spaCy in a virtualenv environment
-#' spacy_install_virtualenv(lang_models = c("en"))
+#' spacy_install_virtualenv(lang_models = c("en_core_web_sm"))
 #' }
 #' @export
 spacy_install_virtualenv <- function(version = "latest",
-                                     lang_models = "en",
+                                     lang_models = "en_core_web_sm",
                                      python_version = "3.6",
                                      python_path = NULL,
                                      prompt = TRUE) {
@@ -450,8 +458,7 @@ spacy_pkgs <- function(version, packages = NULL) {
 #' Uninstall spaCy conda environment
 #'
 #' Removes the conda environment created by spacy_install()
-#' @inheritParams reticulate::conda_list
-#' @param conda Path to conda executable, default to "auto" which automatically
+#' @param conda path to conda executable, default to "auto" which automatically
 #'   finds the path
 #' @param prompt logical; ask whether to proceed during the installation
 #' @param envname character; name of conda environment to remove
@@ -483,14 +490,13 @@ spacy_uninstall <- function(conda = "auto",
 
 #' Upgrade spaCy in conda environment
 #'
-#' @inheritParams reticulate::conda_list
 #' @param conda Path to conda executable. Default "auto" which automatically
 #'   find the path
 #' @param pip \code{TRUE} to use pip for installing spacy. If \code{FALSE}, conda 
 #' package manager with conda-forge channel will be used for installing spacy.
 
 #' @param lang_models Language models to be upgraded. Default NULL (No upgrade). 
-#'   A vector of multiple model names can be used (e.g. \code{c("en", "de")})
+#'   A vector of multiple model names can be used (e.g. \code{c("en_core_web_sm", "de_core_web_sm")})
 #' @param prompt logical; ask whether to proceed during the installation
 #' @param envname character; name of conda environment to upgrade spaCy
 #' @export
@@ -498,7 +504,7 @@ spacy_upgrade  <- function(conda = "auto",
                            envname = "spacy_condaenv",
                            prompt = TRUE,
                            pip = FALSE,
-                           lang_models = "en") {
+                           lang_models = "en_core_web_sm") {
 
     message("checking spaCy version")
     conda <- reticulate::conda_binary(conda)

--- a/R/spacy_parse.R
+++ b/R/spacy_parse.R
@@ -82,7 +82,7 @@ spacy_parse.character <- function(x,
                                   multithread = TRUE,
                                   additional_attributes = NULL,
                                   ...) {
-
+    x <- as.character(x)
     `:=` <- `.` <- `.N` <- NULL
     spacy_out <- process_document(x, multithread)
     if (is.null(spacy_out$timestamps)) {

--- a/R/spacy_parse.R
+++ b/R/spacy_parse.R
@@ -82,7 +82,7 @@ spacy_parse.character <- function(x,
                                   multithread = TRUE,
                                   additional_attributes = NULL,
                                   ...) {
-    x <- as.character(x)
+    x <- structure(as.character(x), names = names(x))
     `:=` <- `.` <- `.N` <- NULL
     spacy_out <- process_document(x, multithread)
     if (is.null(spacy_out$timestamps)) {

--- a/R/spacy_tokenize.R
+++ b/R/spacy_tokenize.R
@@ -62,6 +62,7 @@ spacy_tokenize.character <- function(x,
                                      multithread = TRUE,
                                      output = c("list", "data.frame"),
                                      ...) {
+    x <- as.character(x)
     output <- match.arg(output)
     what <- match.arg(what)
 

--- a/R/spacy_tokenize.R
+++ b/R/spacy_tokenize.R
@@ -62,7 +62,7 @@ spacy_tokenize.character <- function(x,
                                      multithread = TRUE,
                                      output = c("list", "data.frame"),
                                      ...) {
-    x <- as.character(x)
+    x <- structure(as.character(x), names = names(x))
     output <- match.arg(output)
     what <- match.arg(what)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ build_script:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - "conda create --name spacy_condaenv python=3.6.8 conda-forge::spacy"
+  - "conda create --name spacy_condaenv python=3.6 conda-forge::spacy"
   # - "%PYTHON%\\python.exe -m pip install setuptools spacy"
   # - "%PYTHON%\\python.exe -m spacy download en"
   - activate spacy_condaenv 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,8 @@ build_script:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - "conda create --name spacy_condaenv python=3.6 conda-forge::spacy"
+  - "conda create --name spacy_condaenv python=3.6"
+  - "conda install -n spacy_conaenv -c conda-forge spacy"
   # - "%PYTHON%\\python.exe -m pip install setuptools spacy"
   # - "%PYTHON%\\python.exe -m spacy download en"
   - activate spacy_condaenv 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,6 +40,8 @@ build_script:
   # - "%PYTHON%\\python.exe -m spacy download en"
   - activate spacy_condaenv 
   - python -m spacy download en
+  # following line is from: https://github.com/numpy/numpy/issues/14747
+  - pip install --upgrade --force-reinstall numpy 
   - deactivate
   - travis-tool.sh install_deps
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,7 @@ build_script:
   - conda update -q conda
   - conda info -a
   - "conda create --name spacy_condaenv python=3.6"
-  - "conda install -n spacy_conaenv -c conda-forge spacy"
+  - "conda install -n spacy_condaenv -c conda-forge spacy"
   # - "%PYTHON%\\python.exe -m pip install setuptools spacy"
   # - "%PYTHON%\\python.exe -m spacy download en"
   - activate spacy_condaenv 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,7 +40,7 @@ build_script:
   # - "%PYTHON%\\python.exe -m spacy download en"
   - activate spacy_condaenv 
   - python -m spacy download en
-  - conda deactivate
+  - deactivate
   - travis-tool.sh install_deps
 
 test_script:

--- a/man/entity_extract.Rd
+++ b/man/entity_extract.Rd
@@ -5,8 +5,7 @@
 \alias{entity_consolidate}
 \title{Extract or consolidate entities from parsed documents}
 \usage{
-entity_extract(x, type = c("named", "extended", "all"),
-  concatenator = "_")
+entity_extract(x, type = c("named", "extended", "all"), concatenator = "_")
 
 entity_consolidate(x, concatenator = "_")
 }

--- a/man/get-functions.Rd
+++ b/man/get-functions.Rd
@@ -63,7 +63,7 @@ A collection of get methods for spacyr return objects (of \code{spacy_out} class
 \examples{
 \donttest{
 # get_tags examples
-txt <- c(text1 = "This is the first sentence.\\nHere is the second sentence.", 
+txt <- c(text1 = "This is the first sentence.\nHere is the second sentence.", 
          text2 = "This is the second document.")
 results <- spacy_parse(txt)
 tokens <- tokens(results)

--- a/man/process_document.Rd
+++ b/man/process_document.Rd
@@ -30,7 +30,7 @@ object. To obtain the tokens results in R, use \code{get_tokens()}.
 \donttest{
 spacy_initialize()
 # the result has to be "tag() is ready to run" to run the following
-txt <- c(text1 = "This is the first sentence.\\nHere is the second sentence.", 
+txt <- c(text1 = "This is the first sentence.\nHere is the second sentence.", 
          text2 = "This is the second document.")
 results <- spacy_parse(txt)
 }

--- a/man/spacy_download_langmodel.Rd
+++ b/man/spacy_download_langmodel.Rd
@@ -5,11 +5,17 @@
 \alias{spacy_download_langmodel_virtualenv}
 \title{Install a language model in a conda or virtual environment}
 \usage{
-spacy_download_langmodel(model = "en", envname = "spacy_condaenv",
-  conda = "auto")
+spacy_download_langmodel(
+  model = "en",
+  envname = "spacy_condaenv",
+  conda = "auto"
+)
 
-spacy_download_langmodel_virtualenv(model = "en",
-  envname = "spacy_virtualenv", virtualenv_root = NULL)
+spacy_download_langmodel_virtualenv(
+  model = "en",
+  envname = "spacy_virtualenv",
+  virtualenv_root = NULL
+)
 }
 \arguments{
 \item{model}{name of the language model to be installed.  A list of available

--- a/man/spacy_extract_entity.Rd
+++ b/man/spacy_extract_entity.Rd
@@ -4,8 +4,13 @@
 \alias{spacy_extract_entity}
 \title{Extract named entities from texts using spaCy}
 \usage{
-spacy_extract_entity(x, output = c("data.frame", "list"),
-  type = c("all", "named", "extended"), multithread = TRUE, ...)
+spacy_extract_entity(
+  x,
+  output = c("data.frame", "list"),
+  type = c("all", "named", "extended"),
+  multithread = TRUE,
+  ...
+)
 }
 \arguments{
 \item{x}{a character object or a TIF-compliant

--- a/man/spacy_extract_nounphrases.Rd
+++ b/man/spacy_extract_nounphrases.Rd
@@ -4,8 +4,12 @@
 \alias{spacy_extract_nounphrases}
 \title{Extract noun phrases from texts using spaCy}
 \usage{
-spacy_extract_nounphrases(x, output = c("data.frame", "list"),
-  multithread = TRUE, ...)
+spacy_extract_nounphrases(
+  x,
+  output = c("data.frame", "list"),
+  multithread = TRUE,
+  ...
+)
 }
 \arguments{
 \item{x}{a character object or a TIF-compliant corpus data.frame (see

--- a/man/spacy_initialize.Rd
+++ b/man/spacy_initialize.Rd
@@ -4,10 +4,17 @@
 \alias{spacy_initialize}
 \title{Initialize spaCy}
 \usage{
-spacy_initialize(model = "en", python_executable = NULL,
-  virtualenv = NULL, condaenv = NULL, ask = FALSE,
-  refresh_settings = FALSE, save_profile = FALSE, check_env = TRUE,
-  entity = TRUE)
+spacy_initialize(
+  model = "en",
+  python_executable = NULL,
+  virtualenv = NULL,
+  condaenv = NULL,
+  ask = FALSE,
+  refresh_settings = FALSE,
+  save_profile = FALSE,
+  check_env = TRUE,
+  entity = TRUE
+)
 }
 \arguments{
 \item{model}{Language package for loading spaCy. Example: \code{en} (English) and

--- a/man/spacy_install.Rd
+++ b/man/spacy_install.Rd
@@ -5,12 +5,24 @@
 \alias{spacy_install_virtualenv}
 \title{Install spaCy in conda or virtualenv environment}
 \usage{
-spacy_install(conda = "auto", version = "latest", lang_models = "en",
-  python_version = "3.6", envname = "spacy_condaenv", pip = FALSE,
-  python_path = NULL, prompt = TRUE)
+spacy_install(
+  conda = "auto",
+  version = "latest",
+  lang_models = "en_core_web_sm",
+  python_version = "3.6",
+  envname = "spacy_condaenv",
+  pip = FALSE,
+  python_path = NULL,
+  prompt = TRUE
+)
 
-spacy_install_virtualenv(version = "latest", lang_models = "en",
-  python_version = "3.6", python_path = NULL, prompt = TRUE)
+spacy_install_virtualenv(
+  version = "latest",
+  lang_models = "en_core_web_sm",
+  python_version = "3.6",
+  python_path = NULL,
+  prompt = TRUE
+)
 }
 \arguments{
 \item{conda}{character; path to conda executable. Default "auto" which
@@ -23,8 +35,8 @@ automatically find the path}
   You can also provide a full major.minor.patch specification (e.g. "1.1.0")}
 
 \item{lang_models}{character; language models to be installed. Default
-\code{en} (English model). A vector of multiple model names can be used
-(e.g. \code{c("en", "de")}).  A list of available language models and their
+\code{en_core_web_sm} (English model). A vector of multiple model names can be used
+(e.g. \code{c("en_core_web_sm", "de_core_news_sm")}).  A list of available language models and their
 names is available from the \href{https://spacy.io/usage/models}{spaCy
 language models} page.}
 
@@ -73,7 +85,7 @@ If you wish to install Python ion a "virtualenv", use the
 \examples{
 \dontrun{
 # install spaCy in a miniconda environment (macOS and Linux)
-spacy_install(lang_models = c("en", "de"), prompt = FALSE)
+spacy_install(lang_models = c("en_core_web_sm", "de_core_news_sm"), prompt = FALSE)
 
 # install spaCy to an existing conda environment
 spacy_install(conda = "~/anaconda/bin/")
@@ -81,6 +93,6 @@ spacy_install(conda = "~/anaconda/bin/")
 
 \dontrun{
 # install spaCy in a virtualenv environment
-spacy_install_virtualenv(lang_models = c("en"))
+spacy_install_virtualenv(lang_models = c("en_core_web_sm"))
 }
 }

--- a/man/spacy_parse.Rd
+++ b/man/spacy_parse.Rd
@@ -4,9 +4,18 @@
 \alias{spacy_parse}
 \title{Parse a text using spaCy}
 \usage{
-spacy_parse(x, pos = TRUE, tag = FALSE, lemma = TRUE,
-  entity = TRUE, dependency = FALSE, nounphrase = FALSE,
-  multithread = TRUE, additional_attributes = NULL, ...)
+spacy_parse(
+  x,
+  pos = TRUE,
+  tag = FALSE,
+  lemma = TRUE,
+  entity = TRUE,
+  dependency = FALSE,
+  nounphrase = FALSE,
+  multithread = TRUE,
+  additional_attributes = NULL,
+  ...
+)
 }
 \arguments{
 \item{x}{a character object, a \pkg{quanteda} corpus, or a TIF-compliant
@@ -70,7 +79,7 @@ spacy_parse(txt, dependency = TRUE)
 
 txt2 <- c(doc1 = "The fast cat catches mice.\\\\nThe quick brown dog jumped.", 
           doc2 = "This is the second document.",
-          doc3 = "This is a \\\\\\"quoted\\\\\\" text." )
+          doc3 = "This is a \\\\\"quoted\\\\\" text." )
 spacy_parse(txt2, entity = TRUE, dependency = TRUE)
 
 txt3 <- "We analyzed the Supreme Court with three natural language processing tools." 

--- a/man/spacy_tokenize.Rd
+++ b/man/spacy_tokenize.Rd
@@ -4,10 +4,19 @@
 \alias{spacy_tokenize}
 \title{Tokenize text with spaCy}
 \usage{
-spacy_tokenize(x, what = c("word", "sentence"), remove_punct = FALSE,
-  remove_url = FALSE, remove_numbers = FALSE,
-  remove_separators = TRUE, remove_symbols = FALSE, padding = FALSE,
-  multithread = TRUE, output = c("list", "data.frame"), ...)
+spacy_tokenize(
+  x,
+  what = c("word", "sentence"),
+  remove_punct = FALSE,
+  remove_url = FALSE,
+  remove_numbers = FALSE,
+  remove_separators = TRUE,
+  remove_symbols = FALSE,
+  padding = FALSE,
+  multithread = TRUE,
+  output = c("list", "data.frame"),
+  ...
+)
 }
 \arguments{
 \item{x}{a character object, a \pkg{quanteda} corpus, or a TIF-compliant
@@ -57,7 +66,7 @@ spacy_tokenize(txt)
 
 txt2 <- c(doc1 = "The fast cat catches mice.\\\\nThe quick brown dog jumped.", 
           doc2 = "This is the second document.",
-          doc3 = "This is a \\\\\\"quoted\\\\\\" text." )
+          doc3 = "This is a \\\\\"quoted\\\\\" text." )
 spacy_tokenize(txt2)
 }
 }

--- a/man/spacy_uninstall.Rd
+++ b/man/spacy_uninstall.Rd
@@ -4,11 +4,10 @@
 \alias{spacy_uninstall}
 \title{Uninstall spaCy conda environment}
 \usage{
-spacy_uninstall(conda = "auto", prompt = TRUE,
-  envname = "spacy_condaenv")
+spacy_uninstall(conda = "auto", prompt = TRUE, envname = "spacy_condaenv")
 }
 \arguments{
-\item{conda}{Path to conda executable, default to "auto" which automatically
+\item{conda}{path to conda executable, default to "auto" which automatically
 finds the path}
 
 \item{prompt}{logical; ask whether to proceed during the installation}

--- a/man/spacy_upgrade.Rd
+++ b/man/spacy_upgrade.Rd
@@ -4,8 +4,13 @@
 \alias{spacy_upgrade}
 \title{Upgrade spaCy in conda environment}
 \usage{
-spacy_upgrade(conda = "auto", envname = "spacy_condaenv",
-  prompt = TRUE, pip = FALSE, lang_models = "en")
+spacy_upgrade(
+  conda = "auto",
+  envname = "spacy_condaenv",
+  prompt = TRUE,
+  pip = FALSE,
+  lang_models = "en_core_web_sm"
+)
 }
 \arguments{
 \item{conda}{Path to conda executable. Default "auto" which automatically
@@ -19,7 +24,7 @@ find the path}
 package manager with conda-forge channel will be used for installing spacy.}
 
 \item{lang_models}{Language models to be upgraded. Default NULL (No upgrade). 
-A vector of multiple model names can be used (e.g. \code{c("en", "de")})}
+A vector of multiple model names can be used (e.g. \code{c("en_core_web_sm", "de_core_web_sm")})}
 }
 \description{
 Upgrade spaCy in conda environment

--- a/tests/lint.R
+++ b/tests/lint.R
@@ -1,6 +1,0 @@
-library("testthat")
-
-if (requireNamespace("lintr", quietly = TRUE)) {
-    context("lints")
-    test_that("Package Style", lintr::expect_lint_free())
-}

--- a/tests/testthat/test-3-spacy_tokenize.R
+++ b/tests/testthat/test-3-spacy_tokenize.R
@@ -97,7 +97,7 @@ test_that("spacy_tokenize remove_symbols argument work as expected", {
     )
     expect_equivalent(
         spacy_tokenize(txt, remove_symbols = TRUE, padding = FALSE),
-        list(c("This", ":", "=",  "GBP", "!", "15", "%", "not", "!",
+        list(c("This", ":",  "GBP", "!", "15", "%", "not", "!",
                ">", "20", "percent", "?"))
     )
 })

--- a/tests/testthat/test-4-entity-functions.R
+++ b/tests/testthat/test-4-entity-functions.R
@@ -16,7 +16,7 @@ test_that("spacy_extract_entity data.frame works", {
     expect_equal(
         entities$text,
         c("Gatsby", "Louisiana", "East Side", "New York", "New Haven",
-          "1915", "just a quarter", "Teutonic", "the Great War"))
+          "1915", "just a quarter of a century", "Teutonic", "the Great War"))
     expect_equal(
         entities$ent_type,
         c("PERSON", "GPE", "LOC", "GPE", "GPE", "DATE", "CARDINAL", "NORP", "EVENT"))
@@ -56,7 +56,7 @@ test_that("spacy_extract_entity list works", {
     expect_equal(
         entities,
         list(doc1 = c("Gatsby", "Louisiana", "East Side", "New York"),
-             doc2 = c("New Haven", "1915", "just a quarter",
+             doc2 = c("New Haven", "1915", "just a quarter of a century",
                       "Teutonic", "the Great War"))
     )
 
@@ -139,7 +139,7 @@ test_that("spacy_extract_entity type option works", {
 
     expect_equal(
         unname(unlist(spacy_extract_entity(txt1, output = "list", type = "extended"))),
-        c("1915", "just a quarter")
+        c("1915", "just a quarter of a century")
     )
 
     expect_equal(


### PR DESCRIPTION
Make it so that quanteda v2 corpus objects work with tokenize and parse functions, by stripping their attributes off to leave a simple, named character input.

Implements the **spacyr** side of #1884.