### PR TITLE
fix bug for spacy_upgrade when pip=FALSE

### DIFF
--- a/R/spacy_initialize.R
+++ b/R/spacy_initialize.R
@@ -2,8 +2,8 @@
 #' 
 #' Initialize spaCy to call from R. 
 #' @return NULL
-#' @param model Language package for loading spaCy. Example: \code{en} (English) and
-#' \code{de} (German). Default is \code{en}.
+#' @param model Language package for loading spaCy. Example: \code{en_core_web_sm} (English) and
+#' \code{de_core_web_sm} (German). Default is \code{en_core_web_sm}.
 #' @param python_executable the full path to the Python executable, for which
 #'   spaCy is installed
 #' @param ask logical; if \code{FALSE}, use the first spaCy installation found;
@@ -27,7 +27,7 @@
 #'   be saved for the future use.
 #' @export
 #' @author Akitaka Matsuo
-spacy_initialize <- function(model = "en",
+spacy_initialize <- function(model = "en_core_web_sm",
                              python_executable = NULL,
                              virtualenv = NULL,
                              condaenv = NULL,
@@ -129,7 +129,7 @@ spacy_finalize <- function() {
 #'  
 #' @keywords internal
 #' @importFrom data.table data.table
-find_spacy <- function(model = "en", ask){
+find_spacy <- function(model = "en_core_web_sm", ask){
     spacy_found <- `:=` <- NA
     spacy_python <- NULL
     options(warn = -1)

--- a/R/spacy_install.R
+++ b/R/spacy_install.R
@@ -451,7 +451,7 @@ python_version <- function(python) {
 spacy_pkgs <- function(version, packages = NULL) {
     if (is.null(packages))
         packages <- sprintf("spacy%s",
-                            ifelse(version == "latest", "", paste0("==", version)))
+                            ifelse(version == "latest", "", paste0("=", version)))
     return(packages)
 }
 
@@ -536,7 +536,7 @@ spacy_upgrade  <- function(conda = "auto",
             cat("spaCy will be upgraded to version", latest_spacy, "\n")
             process_spacy_installation_conda(conda = conda,
                                              envname = envname,
-                                             version = "latest",
+                                             version = latest_spacy,
                                              lang_models = lang_models,
                                              python_version = "3.6",
                                              prompt = FALSE)
@@ -584,7 +584,7 @@ spacy_upgrade  <- function(conda = "auto",
             }
             process_spacy_installation_conda(conda = conda,
                                              envname = envname,
-                                             version = "latest",
+                                             version = latest_spacy,
                                              lang_models = lang_models,
                                              python_version = "3.6",
                                              prompt = FALSE,

--- a/R/spacy_install.R
+++ b/R/spacy_install.R
@@ -541,7 +541,8 @@ spacy_upgrade  <- function(conda = "auto",
                                              python_version = "3.6",
                                              prompt = FALSE)
             message("\nSuccessfully upgraded\n",
-                    sprintf("Condaenv: %s; Langage model(s): ", envname), lang_models, "\n")
+                    sprintf("Condaenv: %s; Langage model(s): ", envname), lang_models, "\n",
+                    "For the upgrade to take effect, please restart R session")
         } else {
             if (pip == TRUE) {
                 cmd <- sprintf("%s%s %s && pip install --upgrade %s %s%s",
@@ -590,7 +591,8 @@ spacy_upgrade  <- function(conda = "auto",
                                              prompt = FALSE,
                                              pip = pip)
             message("\nSuccessfully upgraded\n",
-                    sprintf("Condaenv: %s; Langage model(s): ", envname), lang_models, "\n")
+                    sprintf("Condaenv: %s; Langage model(s): ", envname), lang_models, "\n",
+                    "For the upgrade to take effect, please restart R session")
 
         } else {
             message("No upgrade is chosen")

--- a/R/spacy_parse.R
+++ b/R/spacy_parse.R
@@ -108,7 +108,7 @@ spacy_parse.character <- function(x,
     if (lemma) {
         model <- spacyr_pyget("model")
         dt[, "lemma" := get_attrs(spacy_out, "lemma_", TRUE)]
-        if (model != "en"){
+        if (substr(model, 0, 2) != "en"){
             warning("lemmatization may not work properly in model '", model, "'")
         }
     }

--- a/man/find_spacy.Rd
+++ b/man/find_spacy.Rd
@@ -4,7 +4,7 @@
 \alias{find_spacy}
 \title{Find spaCy}
 \usage{
-find_spacy(model = "en", ask)
+find_spacy(model = "en_core_web_sm", ask)
 }
 \arguments{
 \item{model}{name of the language model}

--- a/man/spacy_initialize.Rd
+++ b/man/spacy_initialize.Rd
@@ -5,7 +5,7 @@
 \title{Initialize spaCy}
 \usage{
 spacy_initialize(
-  model = "en",
+  model = "en_core_web_sm",
   python_executable = NULL,
   virtualenv = NULL,
   condaenv = NULL,
@@ -17,8 +17,8 @@ spacy_initialize(
 )
 }
 \arguments{
-\item{model}{Language package for loading spaCy. Example: \code{en} (English) and
-\code{de} (German). Default is \code{en}.}
+\item{model}{Language package for loading spaCy. Example: \code{en_core_web_sm} (English) and
+\code{de_core_web_sm} (German). Default is \code{en_core_web_sm}.}
 
 \item{python_executable}{the full path to the Python executable, for which
 spaCy is installed}


### PR DESCRIPTION
Close #183 

The issue was: 

- When `conda install` was used internally, conda will not update the package unless the version number is explicitly provided. 

Solution:

- Handing the specific version number when calling an internal function `process_spacy_installation_conda()`, instead of just saying "latest".