### PR TITLE
Add update_conda option to spacy_upgrade

### DIFF
--- a/R/spacy_install.R
+++ b/R/spacy_install.R
@@ -669,25 +669,3 @@ conda_get_version <- function(major_version = NA, conda, envname) {
     return(result[length(result)])
 }
 
-
-conda_create <- function(envname = NULL, packages = "python", conda = "auto") {
-    
-    # resolve conda binary
-    conda <- conda_binary(conda)
-    
-    # resolve environment name
-    envname <- condaenv_resolve(envname)
-    
-    # create the environment
-    args <- conda_args("create", envname, packages)
-    result <- system2(conda, shQuote(args))
-    if (result != 0L) {
-        stop("Error ", result, " occurred creating conda environment ", envname,
-             call. = FALSE)
-    }
-    
-    # return the path to the python binary
-    conda_python(envname = envname, conda = conda)
-    
-}
-

--- a/R/spacy_install.R
+++ b/R/spacy_install.R
@@ -499,19 +499,29 @@ spacy_uninstall <- function(conda = "auto",
 #'   A vector of multiple model names can be used (e.g. \code{c("en_core_web_sm", "de_core_web_sm")})
 #' @param prompt logical; ask whether to proceed during the installation
 #' @param envname character; name of conda environment to upgrade spaCy
+#' @param update_conda logical; If \code{true}, the conda binary for the system will be updated to the latest version. 
+#'  Default \code{FALSE}.
 #' @export
 spacy_upgrade  <- function(conda = "auto",
                            envname = "spacy_condaenv",
                            prompt = TRUE,
                            pip = FALSE,
+                           update_conda = FALSE,
                            lang_models = "en_core_web_sm") {
 
-    message("checking spaCy version")
     conda <- reticulate::conda_binary(conda)
     if (!(envname %in% reticulate::conda_list(conda = conda)$name)) {
         message("Conda evnronment", envname, "does not exist")
     }
-
+    
+    if (update_conda == TRUE) {
+        message("Update conda binary")
+        args <- reticulate:::conda_args("update", "root", "conda")
+        result <- system2(conda, shQuote(args))
+        message("Conda is updated\n")
+    }
+    
+    message("checking spaCy version")
     condaenv_bin <- function(bin) path.expand(file.path(dirname(conda), bin))
     cmd <- sprintf("%s%s %s && pip search spacy%s",
                    ifelse(is_windows(), "", ifelse(is_osx(), "source ", "/bin/bash -c \"source ")),
@@ -658,3 +668,26 @@ conda_get_version <- function(major_version = NA, conda, envname) {
     #version_check_regex <- sprintf(".+(%s.\\d+\\.\\d+).+", major_version)
     return(result[length(result)])
 }
+
+
+conda_create <- function(envname = NULL, packages = "python", conda = "auto") {
+    
+    # resolve conda binary
+    conda <- conda_binary(conda)
+    
+    # resolve environment name
+    envname <- condaenv_resolve(envname)
+    
+    # create the environment
+    args <- conda_args("create", envname, packages)
+    result <- system2(conda, shQuote(args))
+    if (result != 0L) {
+        stop("Error ", result, " occurred creating conda environment ", envname,
+             call. = FALSE)
+    }
+    
+    # return the path to the python binary
+    conda_python(envname = envname, conda = conda)
+    
+}
+

--- a/man/spacy_upgrade.Rd
+++ b/man/spacy_upgrade.Rd
@@ -9,6 +9,7 @@ spacy_upgrade(
   envname = "spacy_condaenv",
   prompt = TRUE,
   pip = FALSE,
+  update_conda = FALSE,
   lang_models = "en_core_web_sm"
 )
 }
@@ -22,6 +23,9 @@ find the path}
 
 \item{pip}{\code{TRUE} to use pip for installing spacy. If \code{FALSE}, conda 
 package manager with conda-forge channel will be used for installing spacy.}
+
+\item{update_conda}{logical; If \code{true}, the conda binary for the system will be updated to the latest version. 
+Default \code{FALSE}.}
 
 \item{lang_models}{Language models to be upgraded. Default NULL (No upgrade). 
 A vector of multiple model names can be used (e.g. \code{c("en_core_web_sm", "de_core_web_sm")})}


### PR DESCRIPTION
This is a small functional enhancement for spacy_upgrade dealing with a suggestion by @kbenoit in https://github.com/quanteda/spacyr/pull/186#issuecomment-592415008

> Should the install script also use a newer version of conda? I see
> ```
> ==> WARNING: A newer version of conda exists. <==
>   current version: 4.7.10
>   latest version: 4.8.2
> ```

