### PR TITLE
Fixed 'install' misspelling in documentation

### DIFF
--- a/R/spacy_initialize.R
+++ b/R/spacy_initialize.R
@@ -20,7 +20,7 @@
 #'   \url{https://spacy.io/usage/processing-pipelines}. The option \code{FALSE}
 #'   is available only for spaCy version 2.0.0 or higher.
 #' @param check_env logical; check whether conda/virtual environment generated
-#'   by \code{spacyr_istall()} exists
+#'   by \code{spacyr_install()} exists
 #' @param refresh_settings logical; if \code{TRUE}, spacyr will ignore the saved
 #'   settings in the profile and initiate a search of new settings.
 #' @param save_profile logical; if \code{TRUE}, the current spaCy setting will

--- a/man/spacy_initialize.Rd
+++ b/man/spacy_initialize.Rd
@@ -41,7 +41,7 @@ settings in the profile and initiate a search of new settings.}
 be saved for the future use.}
 
 \item{check_env}{logical; check whether conda/virtual environment generated
-by \code{spacyr_istall()} exists}
+by \code{spacyr_install()} exists}
 
 \item{entity}{logical; if \code{FALSE} is selected, named entity recognition
 is turned off in spaCy. This will speed up the parsing as it will exclude


### PR DESCRIPTION
I just added one character